### PR TITLE
Fix broken Quickstart link on intro page

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -7,7 +7,7 @@ This library works with all types of Neo4j deployments, whether on-premise or cl
 
 ## Documentation
 
-- To get started, see the link:quickstart[Quickstart] page.
+- To get started, see the link:gettingstarted[Getting Started] page.
 - For details on the available Python classes, see the link:neo4jstore[Neo4j Store] page.
 - Example code fragments are available under link:examples[Examples].
 - If you want to contribute to this project, see link:contributing[Contributing].


### PR DESCRIPTION
## Summary

The "Quickstart" link on the [introduction page](https://neo4j.com/labs/rdflib-neo4j/1.1/) points to `/labs/rdflib-neo4j/1.1/quickstart`, which returns a 404. The actual page is `gettingstarted.adoc`, served at `/labs/rdflib-neo4j/1.1/gettingstarted/`.

Updated the link target from `quickstart` to `gettingstarted`, and changed the link text to "Getting Started" to match the page title (consistent with other Neo4j Labs projects).
