### PR TITLE
fix(#53): map BNode subjects and objects to bnode:// URIs

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -2,5 +2,6 @@
 * xref:gettingstarted.adoc[Getting Started]
 * xref:neo4jstore.adoc[Neo4j Store]
 * xref:neo4jstoreconfig.adoc[Store Configuration]
+* xref:blank-nodes.adoc[Blank Nodes]
 * xref:examples.adoc[Examples]
 * xref:contributing.adoc[Contributing]

--- a/docs/modules/ROOT/pages/blank-nodes.adoc
+++ b/docs/modules/ROOT/pages/blank-nodes.adoc
@@ -1,0 +1,163 @@
+= Blank Nodes
+[.procedures, opts=header]
+
+== What are blank nodes?
+
+In RDF, a _blank node_ (BNode) is an anonymous resource — a node that has no globally-resolvable URI.
+Blank nodes are commonly produced by OWL restrictions, reification patterns, SPARQL `CONSTRUCT` queries, and many real-world ontologies.
+In Turtle syntax they appear as `_:b1` labels; in programmatic rdflib usage they are created with `rdflib.term.BNode()`.
+
+Blank nodes are intentionally graph-scoped: their identity is only meaningful within a single RDF graph.
+Because Neo4j models every resource by a `uri` property, blank nodes require special treatment before they can be stored.
+
+== How rdflib-neo4j maps blank nodes to Neo4j
+
+When a triple has a blank node as its *subject* or as a non-literal *object*, the store rewrites the BNode
+to a `bnode://` URI before writing to Neo4j.
+The conversion is performed by the `bnode_to_uri()` utility function in `rdflib_neo4j/utils.py`:
+
+[source,python]
+----
+def bnode_to_uri(bnode: BNode) -> str:
+    """Convert a BNode to a bnode:// URI matching n10s behaviour."""
+    return f"bnode://{bnode}"
+----
+
+This matches the behaviour of https://neo4j.com/labs/neosemantics/[neosemantics (n10s)], Neo4j's native RDF plugin.
+
+=== Subject blank nodes
+
+When a triple's subject is a BNode, the synthesized URI is used as the `uri` property of the corresponding `Resource` node in Neo4j.
+
+For example, the blank node `_:b1` becomes:
+
+----
+uri = "bnode://b1"
+----
+
+=== Object blank nodes
+
+When a BNode appears as a relationship target (i.e. a non-literal object), the synthesized URI is used as the `uri` of the target `Resource` node, and a normal Neo4j relationship is created between the two nodes.
+
+=== Identity stability within an import
+
+BNode identity is stable within a single import whenever the blank node identifier is the same.
+Parsing a Turtle file will always use the same string label (e.g. `_:b1`) for each occurrence, so all triples sharing that subject are correctly grouped into one Neo4j node.
+
+[IMPORTANT]
+====
+BNode identity is only stable across imports when the identifier string is preserved.
+If you import two separate files that both contain `_:b1`, those blank nodes will map to the same `bnode://b1` URI and will *merge* in Neo4j due to the `UNIQUE` constraint on `:Resource(uri)`.
+This matches n10s behaviour, but RDF semantics treat blank nodes as graph-scoped — be aware that overlapping identifiers across separate imports will cause unintended merges.
+====
+
+=== Subject grouping fix
+
+The implementation also fixes subject-identity comparison in `__check_current_subject()`.
+Without this fix, consecutive triples sharing the same BNode subject were compared as raw `BNode` objects against the already-normalized `bnode://` URI string, causing each triple to be incorrectly treated as a new subject.
+The comparison now normalizes the incoming subject before comparing, so all triples for the same blank node are collected into a single Neo4j node.
+
+== Python code example
+
+The following example creates a small in-memory RDF graph containing blank nodes — a blank node as a subject, and a blank node as a relationship target — and loads it into Neo4j.
+It then queries Neo4j directly using the Python driver to confirm that the blank nodes are accessible by their synthesized `bnode://` URIs.
+
+[source,python]
+----
+from rdflib import Graph, Namespace, RDF, Literal, URIRef
+from rdflib.term import BNode
+from rdflib_neo4j import Neo4jStoreConfig, Neo4jStore, HANDLE_VOCAB_URI_STRATEGY
+from neo4j import GraphDatabase
+
+# --- Neo4j connection ---
+AUTH_DATA = {
+    "uri": "bolt://localhost:7687",
+    "database": "neo4j",
+    "user": "neo4j",
+    "pwd": "password",
+}
+
+FOAF = Namespace("http://xmlns.com/foaf/0.1/")
+EX   = Namespace("http://example.org/")
+
+# --- Build an in-memory graph with blank nodes ---
+# Turtle equivalent:
+#   _:alice a foaf:Person ; foaf:name "Alice" .
+#   ex:Bob  a foaf:Person ; foaf:name "Bob" ; foaf:knows _:alice .
+
+mem_graph = Graph()
+
+alice = BNode("alice")                     # blank node subject
+bob   = URIRef("http://example.org/Bob")   # regular URI subject
+
+mem_graph.add((alice, RDF.type,    FOAF.Person))
+mem_graph.add((alice, FOAF.name,   Literal("Alice")))
+mem_graph.add((bob,   RDF.type,    FOAF.Person))
+mem_graph.add((bob,   FOAF.name,   Literal("Bob")))
+mem_graph.add((bob,   FOAF.knows,  alice))  # BNode as object
+
+# --- Load into Neo4j ---
+config = Neo4jStoreConfig(
+    auth_data=AUTH_DATA,
+    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,
+    batching=False,
+)
+
+neo4j_graph = Graph(store=Neo4jStore(config=config))
+neo4j_graph.parse(data=mem_graph.serialize(format="turtle"), format="turtle")
+neo4j_graph.close(commit_pending_transaction=True)
+
+# --- Verify via the Neo4j driver ---
+driver = GraphDatabase.driver(AUTH_DATA["uri"], auth=(AUTH_DATA["user"], AUTH_DATA["pwd"]))
+
+with driver.session(database=AUTH_DATA["database"]) as session:
+    # 1. Confirm blank-node Resource exists with a bnode:// URI
+    result = session.run(
+        "MATCH (r:Resource) WHERE r.uri STARTS WITH 'bnode://' RETURN r.uri, r.name"
+    )
+    for record in result:
+        print(f"BNode node  uri={record['r.uri']}  name={record['r.name']}")
+    # Expected: BNode node  uri=bnode://alice  name=Alice
+
+    # 2. Confirm the relationship from Bob → bnode://alice is present
+    result = session.run(
+        """
+        MATCH (bob:Resource {uri: $bob_uri})-[:knows]->(bn:Resource)
+        WHERE bn.uri STARTS WITH 'bnode://'
+        RETURN bob.name AS bob_name, bn.uri AS bnode_uri, bn.name AS bnode_name
+        """,
+        bob_uri=str(EX.Bob),
+    )
+    for record in result:
+        print(
+            f"{record['bob_name']} knows {record['bnode_name']} "
+            f"(stored as {record['bnode_uri']})"
+        )
+    # Expected: Bob knows Alice (stored as bnode://alice)
+
+driver.close()
+----
+
+=== What you will see in Neo4j
+
+After running the example, two `Resource` nodes exist in Neo4j:
+
+|===
+| `uri` | `name` | Labels
+
+| `http://example.org/Bob` | `Bob` | `Resource`, `Person`
+| `bnode://alice`          | `Alice` | `Resource`, `Person`
+|===
+
+And one relationship:
+
+----
+(Resource {uri: "http://example.org/Bob"})-[:knows]->(Resource {uri: "bnode://alice"})
+----
+
+The blank node is fully addressable: any Cypher query can look it up by `uri = "bnode://alice"` or traverse relationships to and from it, just like a regular URI resource.
+
+== Relationship to neosemantics (n10s)
+
+The `bnode://` scheme is the same convention used by n10s when it imports RDF into Neo4j.
+Data loaded by rdflib-neo4j will therefore be compatible with n10s-based tooling that expects blank nodes in this form.

--- a/rdflib_neo4j/Neo4jStore.py
+++ b/rdflib_neo4j/Neo4jStore.py
@@ -11,7 +11,8 @@ from rdflib_neo4j.config.const import NEO4J_DRIVER_USER_AGENT_NAME
 from rdflib_neo4j.config.utils import check_auth_data
 from rdflib_neo4j.query_composers.NodeQueryComposer import NodeQueryComposer
 from rdflib_neo4j.query_composers.RelationshipQueryComposer import RelationshipQueryComposer
-from rdflib_neo4j.utils import handle_neo4j_driver_exception
+from rdflib.term import BNode
+from rdflib_neo4j.utils import handle_neo4j_driver_exception, bnode_to_uri
 
 
 class Neo4jStore(Store):
@@ -257,7 +258,8 @@ class Neo4jStore(Store):
         self.__store_current_subject_rels()
 
     def __create_current_subject(self, subject):
-        return Neo4jTriple(uri=subject,
+        uri = bnode_to_uri(subject) if isinstance(subject, BNode) else subject
+        return Neo4jTriple(uri=uri,
                            prefixes={value: key for key, value in self.config.get_prefixes().items()},
                            # Reversing the Prefix dictionary
                            handle_vocab_uri_strategy=self.handle_vocab_uri_strategy,
@@ -277,7 +279,8 @@ class Neo4jStore(Store):
         if self.current_subject is None:
             self.current_subject = self.__create_current_subject(subject)
         else:
-            if self.current_subject.uri != subject:
+            normalized = bnode_to_uri(subject) if isinstance(subject, BNode) else subject
+            if self.current_subject.uri != normalized:
                 self.__store_current_subject()
                 self.current_subject = self.__create_current_subject(subject)
 

--- a/rdflib_neo4j/Neo4jTriple.py
+++ b/rdflib_neo4j/Neo4jTriple.py
@@ -2,8 +2,8 @@ from collections import defaultdict
 from decimal import Decimal
 from typing import Dict, Set, List
 from rdflib import Literal, URIRef, RDF
-from rdflib.term import Node
-from rdflib_neo4j.utils import handle_vocab_uri
+from rdflib.term import BNode, Node
+from rdflib_neo4j.utils import bnode_to_uri, handle_vocab_uri
 from rdflib_neo4j.config.const import HANDLE_VOCAB_URI_STRATEGY, HANDLE_MULTIVAL_STRATEGY
 
 
@@ -176,4 +176,5 @@ class Neo4jTriple:
         # Getting its relationships
         else:
             rel_type = self.handle_vocab_uri(mappings, predicate)
-            self.add_rel(rel_type, object)
+            to_uri = bnode_to_uri(object) if isinstance(object, BNode) else object
+            self.add_rel(rel_type, to_uri)

--- a/rdflib_neo4j/utils.py
+++ b/rdflib_neo4j/utils.py
@@ -2,7 +2,13 @@ from functools import wraps
 from time import time
 from typing import Dict
 from rdflib import URIRef
+from rdflib.term import BNode
 from rdflib_neo4j.config.const import ShortenStrictException, HANDLE_VOCAB_URI_STRATEGY, NEO4J_DRIVER_DICT_MESSAGE
+
+
+def bnode_to_uri(bnode: BNode) -> str:
+    """Convert a BNode to a bnode:// URI matching n10s behaviour."""
+    return f"bnode://{bnode}"
 
 
 def timing(f):

--- a/test/unit/test_blank_nodes.py
+++ b/test/unit/test_blank_nodes.py
@@ -1,0 +1,131 @@
+"""Unit tests for BNode → bnode:// URI rewriting (issue #53)."""
+
+from rdflib import Literal
+from rdflib.term import BNode, URIRef
+
+from rdflib_neo4j.Neo4jTriple import Neo4jTriple
+from rdflib_neo4j.config.const import HANDLE_VOCAB_URI_STRATEGY, HANDLE_MULTIVAL_STRATEGY
+from rdflib_neo4j.utils import bnode_to_uri
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+EX = "http://www.example.org/indiv/"
+SCHEMA = "http://schema.org/"
+
+
+def make_triple(uri):
+    """Construct a Neo4jTriple without a real Neo4j connection."""
+    return Neo4jTriple(
+        uri=uri,
+        prefixes={"http://www.w3.org/1999/02/22-rdf-syntax-ns#": "rdf"},
+        handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,
+        handle_multival_strategy=HANDLE_MULTIVAL_STRATEGY.OVERWRITE,
+        multival_props_names=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# bnode_to_uri utility
+# ---------------------------------------------------------------------------
+
+class TestBnodeToUri:
+    def test_produces_bnode_scheme(self):
+        b = BNode()
+        result = bnode_to_uri(b)
+        assert result.startswith("bnode://")
+
+    def test_includes_bnode_identifier(self):
+        b = BNode("myid")
+        assert bnode_to_uri(b) == "bnode://myid"
+
+    def test_same_bnode_same_uri(self):
+        b = BNode("stable")
+        assert bnode_to_uri(b) == bnode_to_uri(b)
+
+    def test_different_bnodes_different_uris(self):
+        b1 = BNode()
+        b2 = BNode()
+        assert bnode_to_uri(b1) != bnode_to_uri(b2)
+
+
+# ---------------------------------------------------------------------------
+# BNode subject rewriting in Neo4jTriple
+# ---------------------------------------------------------------------------
+
+class TestBnodeSubject:
+    def test_bnode_subject_rewritten_to_bnode_uri(self):
+        b = BNode("subj1")
+        triple_obj = make_triple(bnode_to_uri(b))
+        assert triple_obj.uri == "bnode://subj1"
+
+    def test_uriref_subject_not_rewritten(self):
+        uri = URIRef(f"{EX}Person1")
+        triple_obj = make_triple(uri)
+        assert triple_obj.uri == uri
+
+    def test_bnode_subject_gets_resource_label_when_no_type(self):
+        b = BNode("subj2")
+        triple_obj = make_triple(bnode_to_uri(b))
+        # No rdf:type triple added — label key defaults to "Resource"
+        assert triple_obj.extract_label_key() == "Resource"
+
+    def test_two_bnodes_same_id_produce_same_uri(self):
+        b1 = BNode("shared")
+        b2 = BNode("shared")
+        assert bnode_to_uri(b1) == bnode_to_uri(b2)
+
+
+# ---------------------------------------------------------------------------
+# BNode object rewriting in relationship triples
+# ---------------------------------------------------------------------------
+
+class TestBnodeObject:
+    def _make_triple_with_rel(self, subject_uri, predicate, obj):
+        """Build a Neo4jTriple and parse one relationship triple into it."""
+        triple_obj = make_triple(subject_uri)
+        triple_obj.parse_triple(
+            triple=(URIRef(subject_uri), predicate, obj),
+            mappings={},
+        )
+        return triple_obj
+
+    def test_bnode_object_rewritten_in_relationship(self):
+        b = BNode("obj1")
+        predicate = URIRef(f"{SCHEMA}knows")
+        triple_obj = self._make_triple_with_rel(
+            f"{EX}Person1", predicate, b
+        )
+        rels = triple_obj.extract_rels()
+        # IGNORE strategy → rel_type is local part "knows"
+        assert "knows" in rels
+        assert "bnode://obj1" in rels["knows"]
+
+    def test_uriref_object_not_rewritten_in_relationship(self):
+        obj = URIRef(f"{EX}Person2")
+        predicate = URIRef(f"{SCHEMA}knows")
+        triple_obj = self._make_triple_with_rel(
+            f"{EX}Person1", predicate, obj
+        )
+        rels = triple_obj.extract_rels()
+        assert obj in rels["knows"]
+
+    def test_literal_object_stored_as_property_not_relationship(self):
+        predicate = URIRef(f"{SCHEMA}name")
+        triple_obj = self._make_triple_with_rel(
+            f"{EX}Person1", predicate, Literal("Alice")
+        )
+        # Literals → props, not rels
+        assert triple_obj.extract_rels() == {}
+        assert "name" in triple_obj.extract_props_names()
+
+    def test_bnode_object_uri_is_stable(self):
+        """Two BNodes with the same identifier yield the same rewritten URI."""
+        b1 = BNode("stable_obj")
+        b2 = BNode("stable_obj")
+        predicate = URIRef(f"{SCHEMA}knows")
+        t1 = self._make_triple_with_rel(f"{EX}Person1", predicate, b1)
+        t2 = self._make_triple_with_rel(f"{EX}Person2", predicate, b2)
+        assert list(t1.extract_rels()["knows"]) == list(t2.extract_rels()["knows"])


### PR DESCRIPTION
## Summary
- Rewrites rdflib `BNode` terms to `bnode://<id>` URI strings before writing to Neo4j
- Matches neosemantics (n10s) behaviour for blank node identity
- Fixes subject-identity comparison in `__check_current_subject()` so consecutive BNode triples for the same blank node are correctly grouped (not spuriously flushed)
- Adds `bnode_to_uri()` utility in `utils.py`

## Test plan
- [ ] 12 unit tests in `test/unit/test_blank_nodes.py` — all passing
- [ ] BNode subject → `bnode://id` in node URI
- [ ] BNode object in relationship → `bnode://id` as target
- [ ] URIRef subjects unchanged
- [ ] Same BNode identifier → same URI (stable identity)

Closes #53