### PR TITLE
feat(#65): add preview/dry-run mode to Neo4jStore

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -2,5 +2,6 @@
 * xref:gettingstarted.adoc[Getting Started]
 * xref:neo4jstore.adoc[Neo4j Store]
 * xref:neo4jstoreconfig.adoc[Store Configuration]
+* xref:preview-mode.adoc[Preview / Dry-Run Mode]
 * xref:examples.adoc[Examples]
 * xref:contributing.adoc[Contributing]

--- a/docs/modules/ROOT/pages/preview-mode.adoc
+++ b/docs/modules/ROOT/pages/preview-mode.adoc
@@ -1,0 +1,103 @@
+= Preview / Dry-Run Mode
+[.procedures, opts=header]
+
+Preview mode lets you inspect the Cypher queries that _would_ be sent to Neo4j during an RDF import—without actually executing them.
+This is useful for testing, debugging, and CI pipelines where a live database is not available or where you want to validate generated queries before running a real import.
+
+== How it works
+
+When `preview=True` is set on `Neo4jStoreConfig`, the store intercepts every Cypher write query and appends a `(query, params)` tuple to an in-memory buffer instead of sending it to Neo4j.
+The buffer is accessible via `Neo4jStore.get_preview_results()` and can be cleared with `Neo4jStore.clear_preview_results()`.
+
+NOTE: The store still requires valid credentials or a driver so that it can open a session and perform the uniqueness constraint check.
+No data is written to the database in preview mode.
+If the required `Resource(uri)` uniqueness constraint is missing, a warning is printed and constraint creation is skipped rather than executed against Neo4j.
+
+== Configuration parameter
+
+|===
+| Name | Type | Required | Default | Description
+| preview | Boolean | False | False | When `True`, Cypher write queries are captured in memory instead of being executed against Neo4j.
+|===
+
+== Usage example
+
+[source,python]
+----
+from rdflib import Graph
+from rdflib_neo4j import Neo4jStoreConfig, Neo4jStore
+
+auth_data = {
+    "uri": "bolt://localhost:7687",
+    "database": "neo4j",
+    "user": "neo4j",
+    "pwd": "password",
+}
+
+TURTLE_DATA = """
+@prefix ex: <http://example.org/> .
+ex:Alice a ex:Person ;
+         ex:name "Alice" .
+ex:Bob   a ex:Person ;
+         ex:name "Bob" .
+ex:Alice ex:knows ex:Bob .
+"""
+
+# Enable preview mode in the config
+config = Neo4jStoreConfig(auth_data=auth_data, preview=True)
+
+# Create the store and attach it to an rdflib Graph
+store = Neo4jStore(config=config)
+g = Graph(store=store)
+
+# Parse RDF data — Cypher queries are collected, not sent to Neo4j
+g.parse(data=TURTLE_DATA, format="ttl")
+
+# Inspect every (query, params) pair that would have been executed
+for query, params in store.get_preview_results():
+    print(query)
+    print(params)
+    print()
+
+# Clear the buffer to reset state between parse operations
+store.clear_preview_results()
+----
+
+== API reference
+
+=== get_preview_results
+
+Returns a copy of the list of `(query, params)` tuples collected during the import.
+Calling this method when `preview=False` always returns an empty list.
+
+==== Output
+
+|===
+| Type | Description
+| List[Tuple[str, dict]] | A list of `(cypher_query, parameters)` pairs in the order they would have been sent to Neo4j.
+|===
+
+=== clear_preview_results
+
+Clears the internal preview buffer.
+Use this to reset state between multiple parse operations within the same store instance.
+
+==== Arguments
+
+No arguments.
+
+== Use cases
+
+Testing without a live database::
+  Unit-test your RDF-to-graph mapping logic by asserting on the generated Cypher queries instead of querying a running Neo4j instance.
+  The test suite uses `unittest.mock` to patch the Neo4j driver so no real connection is needed.
+
+CI/CD validation::
+  Run imports in preview mode in a continuous integration pipeline to catch mapping errors or unexpected query shapes without provisioning a database.
+
+Debugging imports::
+  Inspect the exact Cypher that will be executed before committing to a real write operation.
+  This is especially helpful when diagnosing issues with custom mappings, multi-valued properties, or vocabulary URI strategies.
+
+Query auditing::
+  Log or diff the generated Cypher queries between versions of your RDF data to detect unintended changes in the resulting graph structure.

--- a/rdflib_neo4j/Neo4jStore.py
+++ b/rdflib_neo4j/Neo4jStore.py
@@ -34,6 +34,8 @@ class Neo4jStore(Store):
 
         self.batching = config.batching
         self.buffer_max_size = config.batch_size
+        self.preview = config.preview
+        self._preview_results: list = []  # list of (query, params) tuples
 
         self.total_triples = 0
         self.node_buffer_size = 0
@@ -198,6 +200,9 @@ class Neo4jStore(Store):
         constraint_found = next((True for x in result if x["constraint_found"]), False)
 
         if not constraint_found and create:
+            if self.preview:
+                print("Preview mode: skipping constraint creation. Ensure constraint exists before real import.")
+                return
             try:
                 # Create the uniqueness constraint
                 create_constraint = """
@@ -329,13 +334,26 @@ class Neo4jStore(Store):
         """
         Executes a Cypher query on the Neo4j database.
 
+        In preview mode, the query and params are collected instead of executed.
+
         Args:
             query (str): The Cypher query to execute.
             params: The parameters to pass to the query.
         """
+        if self.preview:
+            self._preview_results.append((query, params))
+            return
         try:
             self.session.run(query, params=params)
         except Exception as e:
             e = handle_neo4j_driver_exception(e)
             logging.error(e)
             raise e
+
+    def get_preview_results(self) -> list:
+        """Return list of (query, params) tuples collected in preview mode."""
+        return list(self._preview_results)
+
+    def clear_preview_results(self):
+        """Clear the preview results buffer."""
+        self._preview_results.clear()

--- a/rdflib_neo4j/config/Neo4jStoreConfig.py
+++ b/rdflib_neo4j/config/Neo4jStoreConfig.py
@@ -38,10 +38,12 @@ class Neo4jStoreConfig:
             batch_size=5000,
             handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.SHORTEN,
             handle_multival_strategy=HANDLE_MULTIVAL_STRATEGY.OVERWRITE,
-            multival_props_names: List[Tuple[str, str]] = []
+            multival_props_names: List[Tuple[str, str]] = [],
+            preview: bool = False
     ):
         self.default_prefixes = DEFAULT_PREFIXES
         self.auth_data = auth_data
+        self.preview = preview
         self.custom_prefixes = custom_prefixes
         self.custom_mappings = {}
         for mapping in custom_mappings:

--- a/test/unit/test_preview_mode.py
+++ b/test/unit/test_preview_mode.py
@@ -1,0 +1,213 @@
+"""Unit tests for Neo4jStore preview/dry-run mode."""
+from unittest.mock import MagicMock, patch
+
+from rdflib_neo4j.Neo4jStore import Neo4jStore
+from rdflib_neo4j.config.Neo4jStoreConfig import Neo4jStoreConfig
+
+
+def _make_store(preview: bool) -> Neo4jStore:
+    """Create a Neo4jStore with a mocked driver/session (no real connection)."""
+    config = Neo4jStoreConfig(
+        auth_data={
+            "uri": "bolt://localhost",
+            "database": "neo4j",
+            "user": "neo4j",
+            "pwd": "test",
+        },
+        preview=preview,
+    )
+
+    mock_session = MagicMock()
+    # Simulate constraint already existing so the CREATE branch is never entered
+    mock_session.run.return_value = iter([{"constraint_found": True}])
+
+    mock_driver = MagicMock()
+    mock_driver.session.return_value = mock_session
+
+    # Patch GraphDatabase.driver so __get_driver() never opens a socket
+    with patch("rdflib_neo4j.Neo4jStore.GraphDatabase") as mock_gdb:
+        mock_gdb.driver.return_value = mock_driver
+        store = Neo4jStore(config=config)
+
+    # After construction rdflib calls open(); re-attach fresh mocks and re-open
+    store.driver = mock_driver
+    store.session = mock_session
+    store._Neo4jStore__open = True
+    return store
+
+
+def _make_preview_store() -> Neo4jStore:
+    return _make_store(preview=True)
+
+
+def _make_normal_store() -> Neo4jStore:
+    return _make_store(preview=False)
+
+
+# ---------------------------------------------------------------------------
+# Config-level tests
+# ---------------------------------------------------------------------------
+
+
+def test_config_preview_default_is_false():
+    config = Neo4jStoreConfig(
+        auth_data={"uri": "bolt://localhost", "database": "neo4j", "user": "neo4j", "pwd": "test"}
+    )
+    assert config.preview is False
+
+
+def test_config_preview_true():
+    config = Neo4jStoreConfig(
+        auth_data={"uri": "bolt://localhost", "database": "neo4j", "user": "neo4j", "pwd": "test"},
+        preview=True,
+    )
+    assert config.preview is True
+
+
+# ---------------------------------------------------------------------------
+# Store initialisation
+# ---------------------------------------------------------------------------
+
+
+def test_store_preview_flag_propagated():
+    store = _make_preview_store()
+    assert store.preview is True
+
+
+def test_store_normal_flag_propagated():
+    store = _make_normal_store()
+    assert store.preview is False
+
+
+# ---------------------------------------------------------------------------
+# get_preview_results in preview mode
+# ---------------------------------------------------------------------------
+
+
+def test_preview_results_initially_empty():
+    store = _make_preview_store()
+    assert store.get_preview_results() == []
+
+
+def test_preview_results_collected_after_query():
+    store = _make_preview_store()
+    # Directly exercise __query_database via name-mangled accessor
+    query = "UNWIND $rows AS row MERGE (n:Resource {uri: row.uri})"
+    params = {"rows": [{"uri": "http://example.org/s"}]}
+    store._Neo4jStore__query_database(query, params)
+
+    results = store.get_preview_results()
+    assert len(results) == 1
+    assert results[0] == (query, params)
+
+
+def test_preview_results_contain_str_and_dict():
+    store = _make_preview_store()
+    store._Neo4jStore__query_database("MATCH (n) RETURN n", {"foo": "bar"})
+    q, p = store.get_preview_results()[0]
+    assert isinstance(q, str)
+    assert isinstance(p, dict)
+
+
+def test_preview_results_accumulate_multiple_queries():
+    store = _make_preview_store()
+    store._Neo4jStore__query_database("QUERY_A", {"a": 1})
+    store._Neo4jStore__query_database("QUERY_B", {"b": 2})
+    assert len(store.get_preview_results()) == 2
+
+
+def test_get_preview_results_returns_copy():
+    """Mutating the returned list should not affect internal state."""
+    store = _make_preview_store()
+    store._Neo4jStore__query_database("Q", {})
+    results = store.get_preview_results()
+    results.clear()
+    assert len(store.get_preview_results()) == 1
+
+
+# ---------------------------------------------------------------------------
+# session.run NOT called for data queries in preview mode
+# ---------------------------------------------------------------------------
+
+
+def test_session_run_not_called_in_preview_mode():
+    store = _make_preview_store()
+    # Reset mock call count after setup
+    store.session.run.reset_mock()
+
+    store._Neo4jStore__query_database("MERGE (n:Resource {uri: $uri})", {"uri": "http://example.org/x"})
+
+    store.session.run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Normal mode: session.run IS called
+# ---------------------------------------------------------------------------
+
+
+def test_session_run_called_in_normal_mode():
+    store = _make_normal_store()
+    store.session.run.reset_mock()
+
+    query = "MERGE (n:Resource {uri: $uri})"
+    params = {"uri": "http://example.org/x"}
+    store._Neo4jStore__query_database(query, params)
+
+    store.session.run.assert_called_once_with(query, params=params)
+
+
+# ---------------------------------------------------------------------------
+# Normal mode: get_preview_results is always empty
+# ---------------------------------------------------------------------------
+
+
+def test_normal_mode_get_preview_results_empty():
+    store = _make_normal_store()
+    store.session.run.reset_mock()
+
+    store._Neo4jStore__query_database("MERGE (n:Resource {uri: $uri})", {"uri": "http://example.org/x"})
+
+    assert store.get_preview_results() == []
+
+
+# ---------------------------------------------------------------------------
+# clear_preview_results
+# ---------------------------------------------------------------------------
+
+
+def test_clear_preview_results():
+    store = _make_preview_store()
+    store._Neo4jStore__query_database("Q1", {})
+    store._Neo4jStore__query_database("Q2", {})
+    assert len(store.get_preview_results()) == 2
+
+    store.clear_preview_results()
+    assert store.get_preview_results() == []
+
+
+def test_clear_preview_results_idempotent():
+    store = _make_preview_store()
+    store.clear_preview_results()
+    store.clear_preview_results()
+    assert store.get_preview_results() == []
+
+
+# ---------------------------------------------------------------------------
+# Constraint-creation skipped in preview mode
+# ---------------------------------------------------------------------------
+
+
+def test_constraint_creation_skipped_in_preview_mode(capsys):
+    """When constraint is missing and preview=True, creation should be skipped."""
+    store = _make_preview_store()
+    # Simulate constraint NOT found
+    store.session.run.reset_mock()
+    store.session.run.return_value = iter([{"constraint_found": False}])
+
+    store._Neo4jStore__constraint_check(create=True)
+
+    captured = capsys.readouterr()
+    assert "Preview mode" in captured.out
+    # Ensure the CREATE CONSTRAINT query was NOT sent via session.run
+    for call in store.session.run.call_args_list:
+        assert "CREATE CONSTRAINT" not in str(call)


### PR DESCRIPTION
## Summary
- Adds `preview=True` config option to `Neo4jStoreConfig`
- In preview mode, `(query, params)` tuples are collected instead of executed against Neo4j
- `get_preview_results()` returns the collected queries; `clear_preview_results()` resets the buffer
- Constraint creation is skipped in preview mode with a warning printed

## Test plan
- [ ] 15 unit tests in `test/unit/test_preview_mode.py` — all passing
- [ ] `session.run` not called for data writes in preview mode
- [ ] `get_preview_results()` returns `(str, dict)` tuples
- [ ] Normal mode unaffected

Closes #65