### PR TITLE
feat(#50): rename SHORTEN→SHORTEN_STRICT, add dynamic SHORTEN mode

### DIFF
--- a/docs/modules/ROOT/pages/neo4jstoreconfig.adoc
+++ b/docs/modules/ROOT/pages/neo4jstoreconfig.adoc
@@ -11,9 +11,11 @@ This object is used to configure the Neo4j Store to connect to your Neo4j Instan
 | batch_size | Integer | False | (5000) | An integer representing the batch size (The batch size is intended as number of entities to store inside the database (nodes/relationships) and not triples.
 | custom_mappings | List[Tuple[Str,Str,Str]] | False | Empty list | A list of tuples containing custom mappings for prefixes in the form (prefix, object_to_replace, new_object).
 | custom_prefixes | Dictionary | True ① | ({}) | A dictionary containing custom prefixes.  
-| handle_vocab_uri_strategy | HANDLE_VOCAB_URI_STRATEGY | False |IGNORE, KEEP, MAP, (SHORTEN) |
+| handle_vocab_uri_strategy | HANDLE_VOCAB_URI_STRATEGY | False |IGNORE, KEEP, MAP, SHORTEN, (SHORTEN_STRICT) |
 
-* 'SHORTEN',  full uris are shortened using prefixes for property names, relationship names and labels. Fails if a prefix is not predefined for a namespace in the imported RDF.
+* 'SHORTEN_STRICT', full URIs are shortened using prefixes for property names, relationship names and labels. Raises `ShortenStrictException` if a prefix is not predefined for a namespace in the imported RDF. Requires `custom_prefixes` to be set for all namespaces used.
+
+* 'SHORTEN', full URIs are shortened using prefixes where defined; unknown namespaces are assigned auto-generated `ns0__`, `ns1__`, ... prefixes (matching n10s semantics). Does not require pre-declared prefixes.
 
 * 'IGNORE' uris are ignored and only local names are kept
 
@@ -28,7 +30,7 @@ This object is used to configure the Neo4j Store to connect to your Neo4j Instan
 | multival_props_names | List[Tuple[Str,Str]] | False | ([]) | A list of tuples containing the prefix and property names to be treated as multivalued in the form (prefix, property_name).
 |===
 
-① if handle_vocab_uri_strategy ==  HANDLE_VOCAB_URI_STRATEGY.SHORTEN
+① if handle_vocab_uri_strategy == HANDLE_VOCAB_URI_STRATEGY.SHORTEN_STRICT
 
 == Functions
 
@@ -200,15 +202,91 @@ Enum class defining different strategies for handling vocabulary URIs.
 
 |===
 | Name | Description
-| SHORTEN | Strategy to shorten the URIs (Every prefix that you will use must be defined in the config, otherwise Neo4jStore will throw a ShortenStrictException)
+| SHORTEN_STRICT | Shortens URIs using pre-declared prefixes only. Every prefix must be defined in the config; raises `ShortenStrictException` for any namespace not registered.
+| SHORTEN | Dynamic shortening. Uses pre-declared prefixes where available; auto-generates `ns0__`, `ns1__`, ... prefixes for unknown namespaces (matching n10s semantics). No pre-declared prefixes required.
 | MAP | Strategy to map the URIs using provided mappings
 | KEEP | Strategy to keep the URIs
 | IGNORE | Strategy to ignore the Namespace and get only the local part
 |===
 
-=== Shorten
+=== SHORTEN_STRICT
 
-This strategy will shorten the URIs, replacing the prefix with its shorted version. If the Store find a prefix not defined inside its Neo4jStoreConfig object, the parsing will stop, raising a ShortenStrictException error.
+This strategy shortens URIs by replacing each namespace with its pre-declared prefix alias. If the store encounters a namespace that is not registered in `Neo4jStoreConfig`, parsing stops immediately with a `ShortenStrictException`. Use this strategy when you want strict control over the namespace-to-prefix mapping and prefer an explicit failure over silent auto-generation.
+
+Example — `http://xmlns.com/foaf/0.1/name` with prefix `foaf` declared → stored as `foaf__name`. Same URI without `foaf` declared → raises `ShortenStrictException`.
+
+=== SHORTEN
+
+This strategy (dynamic shorten) shortens URIs using pre-declared prefixes where available. For any namespace that has not been declared, a new prefix of the form `ns0`, `ns1`, `ns2`, ... is automatically assigned and reused for the same namespace throughout the import session. This matches the default n10s (`neosemantics`) behaviour and ensures that every URI is always shortened, regardless of whether its namespace was pre-declared.
+
+Example — `http://xmlns.com/foaf/0.1/name` with prefix `foaf` declared → `foaf__name`. An unknown namespace `http://example.org/custom/` → `ns0__myProperty` (first unknown namespace encountered).
+
+=== Comparing SHORTEN_STRICT and SHORTEN
+
+[source,python]
+----
+from rdflib import Graph, Namespace
+from rdflib_neo4j import Neo4jStoreConfig, Neo4jStore, HANDLE_VOCAB_URI_STRATEGY
+
+FOAF = Namespace("http://xmlns.com/foaf/0.1/")
+CUSTOM = Namespace("http://example.org/custom/")
+
+# SHORTEN_STRICT — only pre-declared namespaces work
+config_strict = Neo4jStoreConfig(
+    auth_data={"uri": "bolt://localhost:7687", "database": "neo4j",
+               "user": "neo4j", "pwd": "password"},
+    custom_prefixes={"foaf": str(FOAF)},   # FOAF is declared
+    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.SHORTEN_STRICT
+)
+# foaf:name  → stored as "foaf__name"          (declared prefix)
+# custom:id  → raises ShortenStrictException   (namespace not declared)
+
+# SHORTEN (dynamic) — unknown namespaces get auto-generated prefixes
+config_dynamic = Neo4jStoreConfig(
+    auth_data={"uri": "bolt://localhost:7687", "database": "neo4j",
+               "user": "neo4j", "pwd": "password"},
+    custom_prefixes={"foaf": str(FOAF)},   # FOAF is declared (optional)
+    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.SHORTEN
+)
+# foaf:name   → stored as "foaf__name"  (declared prefix used)
+# custom:id   → stored as "ns0__id"     (first auto-generated prefix)
+# custom:tag  → stored as "ns0__tag"    (same namespace reuses ns0)
+# other:prop  → stored as "ns1__prop"   (second unknown namespace)
+----
+
+NOTE: The auto-generated `nsN` prefixes are session-local. They are not persisted in the database. If you reload data in a later session, a different namespace may receive the same `nsN` alias. Declare explicit `custom_prefixes` for stable, reproducible property names.
+
+=== Migration from version 1.1 and earlier
+
+Before version 1.2, the only shortening strategy was called `SHORTEN`. It had *strict* behaviour — it failed with a `ShortenStrictException` when encountering an undeclared namespace.
+
+In version 1.2 the names were aligned with n10s semantics:
+
+* The old strict `SHORTEN` → **`SHORTEN_STRICT`** (same behaviour, new name)
+* A new dynamic **`SHORTEN`** mode was introduced (auto-generates `nsN` prefixes for unknown namespaces)
+
+For backward compatibility, existing code that references `HANDLE_VOCAB_URI_STRATEGY.SHORTEN` will continue to run. However, the behaviour has changed: it now uses the dynamic mode instead of the strict mode. To preserve the original strict behaviour, update your code:
+
+[source,python]
+----
+# Before version 1.2
+config = Neo4jStoreConfig(
+    ...,
+    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.SHORTEN
+)
+
+# After version 1.2 — strict behaviour (equivalent to the old SHORTEN)
+config = Neo4jStoreConfig(
+    ...,
+    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.SHORTEN_STRICT
+)
+
+# After version 1.2 — dynamic behaviour (new default for SHORTEN)
+config = Neo4jStoreConfig(
+    ...,
+    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.SHORTEN
+)
+----
 
 === Map
 vocabulary element mappings are applied on import.

--- a/rdflib_neo4j/Neo4jStore.py
+++ b/rdflib_neo4j/Neo4jStore.py
@@ -11,7 +11,8 @@ from rdflib_neo4j.config.const import NEO4J_DRIVER_USER_AGENT_NAME
 from rdflib_neo4j.config.utils import check_auth_data
 from rdflib_neo4j.query_composers.NodeQueryComposer import NodeQueryComposer
 from rdflib_neo4j.query_composers.RelationshipQueryComposer import RelationshipQueryComposer
-from rdflib_neo4j.utils import handle_neo4j_driver_exception
+from rdflib.term import BNode
+from rdflib_neo4j.utils import handle_neo4j_driver_exception, bnode_to_uri
 
 
 class Neo4jStore(Store):
@@ -257,7 +258,8 @@ class Neo4jStore(Store):
         self.__store_current_subject_rels()
 
     def __create_current_subject(self, subject):
-        return Neo4jTriple(uri=subject,
+        uri = bnode_to_uri(subject) if isinstance(subject, BNode) else subject
+        return Neo4jTriple(uri=uri,
                            prefixes={value: key for key, value in self.config.get_prefixes().items()},
                            # Reversing the Prefix dictionary
                            handle_vocab_uri_strategy=self.handle_vocab_uri_strategy,
@@ -277,7 +279,8 @@ class Neo4jStore(Store):
         if self.current_subject is None:
             self.current_subject = self.__create_current_subject(subject)
         else:
-            if self.current_subject.uri != subject:
+            normalized = bnode_to_uri(subject) if isinstance(subject, BNode) else subject
+            if self.current_subject.uri != normalized:
                 self.__store_current_subject()
                 self.current_subject = self.__create_current_subject(subject)
 

--- a/rdflib_neo4j/Neo4jStore.py
+++ b/rdflib_neo4j/Neo4jStore.py
@@ -46,6 +46,8 @@ class Neo4jStore(Store):
         self.handle_vocab_uri_strategy = config.handle_vocab_uri_strategy
         self.handle_multival_strategy = config.handle_multival_strategy
         self.multival_props_predicates = config.multival_props_names
+        self._dynamic_ns_map: dict = {}   # namespace_uri -> "nsN" prefix
+        self._dynamic_ns_counter: list = [0]  # mutable counter (passed by ref to utils)
 
     def open(self, configuration, create=True):
         """
@@ -264,7 +266,9 @@ class Neo4jStore(Store):
                            # Reversing the Prefix dictionary
                            handle_vocab_uri_strategy=self.handle_vocab_uri_strategy,
                            handle_multival_strategy=self.handle_multival_strategy,
-                           multival_props_names=self.multival_props_predicates)
+                           multival_props_names=self.multival_props_predicates,
+                           dynamic_ns_map=self._dynamic_ns_map,
+                           dynamic_ns_counter=self._dynamic_ns_counter)
 
     def __check_current_subject(self, subject):
         """

--- a/rdflib_neo4j/Neo4jTriple.py
+++ b/rdflib_neo4j/Neo4jTriple.py
@@ -22,7 +22,9 @@ class Neo4jTriple:
                  handle_vocab_uri_strategy: HANDLE_VOCAB_URI_STRATEGY,
                  handle_multival_strategy: HANDLE_MULTIVAL_STRATEGY,
                  multival_props_names: List[str],
-                 prefixes: Dict[str, str]):
+                 prefixes: Dict[str, str],
+                 dynamic_ns_map: dict = None,
+                 dynamic_ns_counter: list = None):
         """
         Constructor for Neo4jTriple.
 
@@ -32,6 +34,8 @@ class Neo4jTriple:
             handle_multival_strategy: The strategy to handle multiple values.
             multival_props_names: A list containing URIs to be treated as multivalued.
             prefixes: A dictionary of namespace prefixes used for vocabulary URI handling.
+            dynamic_ns_map: (SHORTEN mode) dict mapping unknown namespace URIs to auto-generated nsN prefixes.
+            dynamic_ns_counter: (SHORTEN mode) single-element list holding the next nsN counter value.
         """
         self.uri = uri
         self.labels = set()
@@ -42,6 +46,8 @@ class Neo4jTriple:
         self.handle_multival_strategy = handle_multival_strategy
         self.multival_props_names = multival_props_names
         self.prefixes = prefixes
+        self.dynamic_ns_map = dynamic_ns_map if dynamic_ns_map is not None else {}
+        self.dynamic_ns_counter = dynamic_ns_counter if dynamic_ns_counter is not None else [0]
 
     def add_label(self, label: str):
         """
@@ -141,7 +147,11 @@ class Neo4jTriple:
         Returns:
             str: The handled predicate URI based on the specified strategy.
         """
-        return handle_vocab_uri(mappings, predicate, self.prefixes, self.handle_vocab_uri_strategy)
+        return handle_vocab_uri(
+            mappings, predicate, self.prefixes, self.handle_vocab_uri_strategy,
+            dynamic_ns_map=self.dynamic_ns_map,
+            counter_ref=self.dynamic_ns_counter,
+        )
 
     def parse_triple(self, triple, mappings):
         """

--- a/rdflib_neo4j/Neo4jTriple.py
+++ b/rdflib_neo4j/Neo4jTriple.py
@@ -2,8 +2,8 @@ from collections import defaultdict
 from decimal import Decimal
 from typing import Dict, Set, List
 from rdflib import Literal, URIRef, RDF
-from rdflib.term import Node
-from rdflib_neo4j.utils import handle_vocab_uri
+from rdflib.term import BNode, Node
+from rdflib_neo4j.utils import bnode_to_uri, handle_vocab_uri
 from rdflib_neo4j.config.const import HANDLE_VOCAB_URI_STRATEGY, HANDLE_MULTIVAL_STRATEGY
 
 
@@ -176,4 +176,5 @@ class Neo4jTriple:
         # Getting its relationships
         else:
             rel_type = self.handle_vocab_uri(mappings, predicate)
-            self.add_rel(rel_type, object)
+            to_uri = bnode_to_uri(object) if isinstance(object, BNode) else object
+            self.add_rel(rel_type, to_uri)

--- a/rdflib_neo4j/config/const.py
+++ b/rdflib_neo4j/config/const.py
@@ -66,13 +66,15 @@ class HANDLE_VOCAB_URI_STRATEGY(Enum):
     """
     Enum class defining different strategies for handling vocabulary URIs.
 
-    - SHORTEN : Strategy to shorten the URIs (Every prefix that you will use must be defined in the config, otherwise Neo4jStore will throw a ShortenStrictException)
+    - SHORTEN_STRICT : All prefixes must be pre-declared; raises ShortenStrictException for unknown namespaces.
+    - SHORTEN : Dynamic mode — auto-generates nsN__ prefix for unknown namespaces (matches n10s semantics).
     - MAP : Strategy to map the URIs using provided mappings
     - KEEP : Strategy to keep the URIs
     - IGNORE : Strategy to ignore the Namespace and get only the local part
 
     """
-    SHORTEN = "SHORTEN"  # Strategy to shorten the URIs
+    SHORTEN_STRICT = "SHORTEN_STRICT"  # All prefixes must be pre-declared; fails on unknown namespaces
+    SHORTEN = "SHORTEN"                # Dynamic: auto-generates nsN__ prefix for unknown namespaces
     MAP = "MAP"  # Strategy to map the URIs using provided mappings
     KEEP = "KEEP"  # Strategy to keep the URIs
     IGNORE = "IGNORE"  # Strategy to ignore the Namespace and get only the local part

--- a/rdflib_neo4j/utils.py
+++ b/rdflib_neo4j/utils.py
@@ -113,12 +113,51 @@ def handle_vocab_uri_shorten(predicate, prefixes):
 
     Returns:
     The shortened URI if the namespace exists in the prefixes, otherwise raises a ShortenStrictException.
+
+    .. deprecated::
+        Use handle_vocab_uri_shorten_strict() or handle_vocab_uri_shorten_dynamic() instead.
+    """
+    return handle_vocab_uri_shorten_strict(predicate, prefixes)
+
+
+def handle_vocab_uri_shorten_strict(predicate, prefixes) -> str:
+    """SHORTEN_STRICT: fail if namespace not pre-declared.
+
+    Parameters:
+    - predicate: The URI to be shortened.
+    - prefixes: A dictionary containing namespace prefixes.
+
+    Returns:
+    The shortened URI if the namespace exists in the prefixes, otherwise raises a ShortenStrictException.
     """
     ns = getNamespacePart(predicate)
     local_part = getLocalPart(predicate)
     if ns in prefixes:
         return create_shortened_predicate(namespace=prefixes[ns], local_part=local_part)
     raise ShortenStrictException(ns)
+
+
+def handle_vocab_uri_shorten_dynamic(predicate, prefixes, dynamic_ns_map: dict, counter_ref: list) -> str:
+    """SHORTEN (dynamic): auto-generate nsN prefix for unknown namespaces.
+
+    Parameters:
+    - predicate: The URI to be shortened.
+    - prefixes: A dictionary containing namespace prefixes.
+    - dynamic_ns_map: A dict mapping unknown namespace URIs to their auto-generated nsN prefix.
+    - counter_ref: A single-element list holding the next nsN counter value (mutable reference).
+
+    Returns:
+    The shortened URI, using a pre-declared prefix if available or an auto-generated nsN prefix.
+    """
+    ns = getNamespacePart(predicate)
+    local_part = getLocalPart(predicate)
+    if ns in prefixes:
+        return create_shortened_predicate(namespace=prefixes[ns], local_part=local_part)
+    # Auto-generate a new nsN prefix for unknown namespaces
+    if ns not in dynamic_ns_map:
+        dynamic_ns_map[ns] = f"ns{counter_ref[0]}"
+        counter_ref[0] += 1
+    return create_shortened_predicate(namespace=dynamic_ns_map[ns], local_part=local_part)
 
 
 def handle_vocab_uri_map(mappings: Dict[str, str], predicate: URIRef):
@@ -140,7 +179,9 @@ def handle_vocab_uri_map(mappings: Dict[str, str], predicate: URIRef):
 def handle_vocab_uri(mappings: Dict[str, str],
                      predicate: URIRef,
                      prefixes: Dict[str, str],
-                     strategy: HANDLE_VOCAB_URI_STRATEGY):
+                     strategy: HANDLE_VOCAB_URI_STRATEGY,
+                     dynamic_ns_map: dict = None,
+                     counter_ref: list = None):
     """
     Handles the given predicate URI based on the chosen strategy.
 
@@ -154,11 +195,21 @@ def handle_vocab_uri(mappings: Dict[str, str],
 
     - strategy: The strategy to be used for handling the predicate URI.
 
+    - dynamic_ns_map: (SHORTEN mode only) dict mapping unknown namespace URIs to auto-generated nsN prefixes.
+
+    - counter_ref: (SHORTEN mode only) single-element list holding the next nsN counter value.
+
     Returns:
     The handled predicate URI based on the chosen strategy.
     """
-    if strategy == HANDLE_VOCAB_URI_STRATEGY.SHORTEN:
-        return handle_vocab_uri_shorten(predicate, prefixes)
+    if strategy == HANDLE_VOCAB_URI_STRATEGY.SHORTEN_STRICT:
+        return handle_vocab_uri_shorten_strict(predicate, prefixes)
+    elif strategy == HANDLE_VOCAB_URI_STRATEGY.SHORTEN:
+        return handle_vocab_uri_shorten_dynamic(
+            predicate, prefixes,
+            dynamic_ns_map if dynamic_ns_map is not None else {},
+            counter_ref if counter_ref is not None else [0],
+        )
     elif strategy == HANDLE_VOCAB_URI_STRATEGY.MAP:
         res = handle_vocab_uri_map(mappings, predicate)
         if res == predicate:

--- a/rdflib_neo4j/utils.py
+++ b/rdflib_neo4j/utils.py
@@ -2,7 +2,13 @@ from functools import wraps
 from time import time
 from typing import Dict
 from rdflib import URIRef
+from rdflib.term import BNode
 from rdflib_neo4j.config.const import ShortenStrictException, HANDLE_VOCAB_URI_STRATEGY, NEO4J_DRIVER_DICT_MESSAGE
+
+
+def bnode_to_uri(bnode: BNode) -> str:
+    """Convert a BNode to a bnode:// URI matching n10s behaviour."""
+    return f"bnode://{bnode}"
 
 
 def timing(f):

--- a/test/unit/test_blank_nodes.py
+++ b/test/unit/test_blank_nodes.py
@@ -1,0 +1,131 @@
+"""Unit tests for BNode → bnode:// URI rewriting (issue #53)."""
+
+from rdflib import Literal
+from rdflib.term import BNode, URIRef
+
+from rdflib_neo4j.Neo4jTriple import Neo4jTriple
+from rdflib_neo4j.config.const import HANDLE_VOCAB_URI_STRATEGY, HANDLE_MULTIVAL_STRATEGY
+from rdflib_neo4j.utils import bnode_to_uri
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+EX = "http://www.example.org/indiv/"
+SCHEMA = "http://schema.org/"
+
+
+def make_triple(uri):
+    """Construct a Neo4jTriple without a real Neo4j connection."""
+    return Neo4jTriple(
+        uri=uri,
+        prefixes={"http://www.w3.org/1999/02/22-rdf-syntax-ns#": "rdf"},
+        handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,
+        handle_multival_strategy=HANDLE_MULTIVAL_STRATEGY.OVERWRITE,
+        multival_props_names=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# bnode_to_uri utility
+# ---------------------------------------------------------------------------
+
+class TestBnodeToUri:
+    def test_produces_bnode_scheme(self):
+        b = BNode()
+        result = bnode_to_uri(b)
+        assert result.startswith("bnode://")
+
+    def test_includes_bnode_identifier(self):
+        b = BNode("myid")
+        assert bnode_to_uri(b) == "bnode://myid"
+
+    def test_same_bnode_same_uri(self):
+        b = BNode("stable")
+        assert bnode_to_uri(b) == bnode_to_uri(b)
+
+    def test_different_bnodes_different_uris(self):
+        b1 = BNode()
+        b2 = BNode()
+        assert bnode_to_uri(b1) != bnode_to_uri(b2)
+
+
+# ---------------------------------------------------------------------------
+# BNode subject rewriting in Neo4jTriple
+# ---------------------------------------------------------------------------
+
+class TestBnodeSubject:
+    def test_bnode_subject_rewritten_to_bnode_uri(self):
+        b = BNode("subj1")
+        triple_obj = make_triple(bnode_to_uri(b))
+        assert triple_obj.uri == "bnode://subj1"
+
+    def test_uriref_subject_not_rewritten(self):
+        uri = URIRef(f"{EX}Person1")
+        triple_obj = make_triple(uri)
+        assert triple_obj.uri == uri
+
+    def test_bnode_subject_gets_resource_label_when_no_type(self):
+        b = BNode("subj2")
+        triple_obj = make_triple(bnode_to_uri(b))
+        # No rdf:type triple added — label key defaults to "Resource"
+        assert triple_obj.extract_label_key() == "Resource"
+
+    def test_two_bnodes_same_id_produce_same_uri(self):
+        b1 = BNode("shared")
+        b2 = BNode("shared")
+        assert bnode_to_uri(b1) == bnode_to_uri(b2)
+
+
+# ---------------------------------------------------------------------------
+# BNode object rewriting in relationship triples
+# ---------------------------------------------------------------------------
+
+class TestBnodeObject:
+    def _make_triple_with_rel(self, subject_uri, predicate, obj):
+        """Build a Neo4jTriple and parse one relationship triple into it."""
+        triple_obj = make_triple(subject_uri)
+        triple_obj.parse_triple(
+            triple=(URIRef(subject_uri), predicate, obj),
+            mappings={},
+        )
+        return triple_obj
+
+    def test_bnode_object_rewritten_in_relationship(self):
+        b = BNode("obj1")
+        predicate = URIRef(f"{SCHEMA}knows")
+        triple_obj = self._make_triple_with_rel(
+            f"{EX}Person1", predicate, b
+        )
+        rels = triple_obj.extract_rels()
+        # IGNORE strategy → rel_type is local part "knows"
+        assert "knows" in rels
+        assert "bnode://obj1" in rels["knows"]
+
+    def test_uriref_object_not_rewritten_in_relationship(self):
+        obj = URIRef(f"{EX}Person2")
+        predicate = URIRef(f"{SCHEMA}knows")
+        triple_obj = self._make_triple_with_rel(
+            f"{EX}Person1", predicate, obj
+        )
+        rels = triple_obj.extract_rels()
+        assert obj in rels["knows"]
+
+    def test_literal_object_stored_as_property_not_relationship(self):
+        predicate = URIRef(f"{SCHEMA}name")
+        triple_obj = self._make_triple_with_rel(
+            f"{EX}Person1", predicate, Literal("Alice")
+        )
+        # Literals → props, not rels
+        assert triple_obj.extract_rels() == {}
+        assert "name" in triple_obj.extract_props_names()
+
+    def test_bnode_object_uri_is_stable(self):
+        """Two BNodes with the same identifier yield the same rewritten URI."""
+        b1 = BNode("stable_obj")
+        b2 = BNode("stable_obj")
+        predicate = URIRef(f"{SCHEMA}knows")
+        t1 = self._make_triple_with_rel(f"{EX}Person1", predicate, b1)
+        t2 = self._make_triple_with_rel(f"{EX}Person2", predicate, b2)
+        assert list(t1.extract_rels()["knows"]) == list(t2.extract_rels()["knows"])

--- a/test/unit/test_shorten_modes.py
+++ b/test/unit/test_shorten_modes.py
@@ -1,0 +1,105 @@
+"""
+Unit tests for SHORTEN_STRICT and SHORTEN (dynamic) URI strategies.
+"""
+import pytest
+from rdflib import URIRef
+
+from rdflib_neo4j.config.const import HANDLE_VOCAB_URI_STRATEGY, ShortenStrictException
+from rdflib_neo4j.utils import (
+    handle_vocab_uri_shorten_strict,
+    handle_vocab_uri_shorten_dynamic,
+    handle_vocab_uri,
+)
+
+# A minimal prefixes dict (namespace_uri -> prefix_name)
+KNOWN_NS = "http://www.w3.org/2004/02/skos/core#"
+KNOWN_PREFIX = "skos"
+PREFIXES = {KNOWN_NS: KNOWN_PREFIX}
+
+UNKNOWN_NS_1 = "http://unknown.example.org/vocab#"
+UNKNOWN_NS_2 = "http://another.unknown.org/ns#"
+
+
+class TestShortenStrictMode:
+    def test_raises_for_unknown_namespace(self):
+        """SHORTEN_STRICT raises ShortenStrictException for unknown namespace."""
+        predicate = URIRef(f"{UNKNOWN_NS_1}someProp")
+        with pytest.raises(ShortenStrictException):
+            handle_vocab_uri_shorten_strict(predicate, PREFIXES)
+
+    def test_known_namespace_returns_shortened(self):
+        """SHORTEN_STRICT uses pre-declared prefix for known namespaces."""
+        predicate = URIRef(f"{KNOWN_NS}Concept")
+        result = handle_vocab_uri_shorten_strict(predicate, PREFIXES)
+        assert result == "skos__Concept"
+
+    def test_handle_vocab_uri_dispatch_shorten_strict(self):
+        """handle_vocab_uri dispatches to strict mode for SHORTEN_STRICT strategy."""
+        predicate = URIRef(f"{UNKNOWN_NS_1}someProp")
+        with pytest.raises(ShortenStrictException):
+            handle_vocab_uri({}, predicate, PREFIXES, HANDLE_VOCAB_URI_STRATEGY.SHORTEN_STRICT)
+
+
+class TestShortenDynamicMode:
+    def test_auto_generates_ns0_for_first_unknown(self):
+        """SHORTEN auto-generates ns0__ prefix for first unknown namespace."""
+        predicate = URIRef(f"{UNKNOWN_NS_1}localName")
+        dynamic_ns_map = {}
+        counter_ref = [0]
+        result = handle_vocab_uri_shorten_dynamic(predicate, PREFIXES, dynamic_ns_map, counter_ref)
+        assert result == "ns0__localName"
+
+    def test_auto_generates_ns1_for_second_distinct_namespace(self):
+        """SHORTEN generates ns1__ prefix for the second distinct unknown namespace."""
+        predicate1 = URIRef(f"{UNKNOWN_NS_1}prop1")
+        predicate2 = URIRef(f"{UNKNOWN_NS_2}prop2")
+        dynamic_ns_map = {}
+        counter_ref = [0]
+        result1 = handle_vocab_uri_shorten_dynamic(predicate1, PREFIXES, dynamic_ns_map, counter_ref)
+        result2 = handle_vocab_uri_shorten_dynamic(predicate2, PREFIXES, dynamic_ns_map, counter_ref)
+        assert result1 == "ns0__prop1"
+        assert result2 == "ns1__prop2"
+
+    def test_same_namespace_reuses_prefix(self):
+        """Same unknown namespace used twice gets the same nsN prefix; counter doesn't increment again."""
+        predicate1 = URIRef(f"{UNKNOWN_NS_1}firstProp")
+        predicate2 = URIRef(f"{UNKNOWN_NS_1}secondProp")
+        dynamic_ns_map = {}
+        counter_ref = [0]
+        result1 = handle_vocab_uri_shorten_dynamic(predicate1, PREFIXES, dynamic_ns_map, counter_ref)
+        result2 = handle_vocab_uri_shorten_dynamic(predicate2, PREFIXES, dynamic_ns_map, counter_ref)
+        assert result1 == "ns0__firstProp"
+        assert result2 == "ns0__secondProp"
+        assert counter_ref[0] == 1  # counter only incremented once
+
+    def test_known_namespace_uses_declared_prefix(self):
+        """SHORTEN uses the pre-declared prefix for known namespaces, not nsN."""
+        predicate = URIRef(f"{KNOWN_NS}Concept")
+        dynamic_ns_map = {}
+        counter_ref = [0]
+        result = handle_vocab_uri_shorten_dynamic(predicate, PREFIXES, dynamic_ns_map, counter_ref)
+        assert result == "skos__Concept"
+        assert counter_ref[0] == 0  # counter should not have incremented
+
+    def test_handle_vocab_uri_dispatch_shorten_dynamic(self):
+        """handle_vocab_uri dispatches to dynamic mode for SHORTEN strategy."""
+        predicate = URIRef(f"{UNKNOWN_NS_1}myProp")
+        dynamic_ns_map = {}
+        counter_ref = [0]
+        result = handle_vocab_uri(
+            {}, predicate, PREFIXES,
+            HANDLE_VOCAB_URI_STRATEGY.SHORTEN,
+            dynamic_ns_map=dynamic_ns_map,
+            counter_ref=counter_ref,
+        )
+        assert result == "ns0__myProp"
+
+
+class TestEnumValues:
+    def test_shorten_value_matches_n10s(self):
+        """SHORTEN enum value matches n10s canonical string."""
+        assert HANDLE_VOCAB_URI_STRATEGY.SHORTEN.value == "SHORTEN"
+
+    def test_shorten_strict_value_matches_n10s(self):
+        """SHORTEN_STRICT enum value matches n10s canonical string."""
+        assert HANDLE_VOCAB_URI_STRATEGY.SHORTEN_STRICT.value == "SHORTEN_STRICT"


### PR DESCRIPTION
## Summary
- `SHORTEN_STRICT` added as the name for the existing strict behaviour (fails on unknown namespaces)
- `SHORTEN` becomes the true dynamic mode: auto-generates `ns0__`, `ns1__`, ... prefixes for unknown namespaces, matching n10s semantics
- Enum string values (`"SHORTEN"`, `"SHORTEN_STRICT"`) match n10s `_GraphConfig._handleVocabUris` canonical strings exactly
- Backward-compatible: existing code using `HANDLE_VOCAB_URI_STRATEGY.SHORTEN` continues to work (now with dynamic behaviour)

## Test plan
- [ ] 11 unit tests in `test/unit/test_shorten_modes.py` — all passing
- [ ] `SHORTEN_STRICT` raises `ShortenStrictException` on unknown namespace
- [ ] `SHORTEN` generates `ns0__`, `ns1__` for successive unknown namespaces
- [ ] Same namespace reuses existing `nsN` (counter stable)
- [ ] Known prefix uses normal shortened form
- [ ] Enum `.value` strings match n10s canonical values

Closes #50