### PR TITLE
feat(#52): complete XSD datatype coercion and add lang/custom type config

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -2,5 +2,6 @@
 * xref:gettingstarted.adoc[Getting Started]
 * xref:neo4jstore.adoc[Neo4j Store]
 * xref:neo4jstoreconfig.adoc[Store Configuration]
+* xref:datatype-coercion.adoc[XSD Datatype Coercion]
 * xref:examples.adoc[Examples]
 * xref:contributing.adoc[Contributing]

--- a/docs/modules/ROOT/pages/datatype-coercion.adoc
+++ b/docs/modules/ROOT/pages/datatype-coercion.adoc
@@ -1,0 +1,236 @@
+= XSD Datatype Coercion
+[.procedures, opts=header]
+
+When RDF data is parsed and stored in Neo4j, typed literals must be converted from their RDF representation into Neo4j-native property types.
+This process is called *XSD datatype coercion*.
+The library handles it automatically via the `coerce_literal()` function in `rdflib_neo4j/datatypes.py`, and it is controlled through three optional flags on `Neo4jStoreConfig`.
+
+== How It Works
+
+Every RDF typed literal carries a datatype URI (e.g. `xsd:integer`, `xsd:boolean`).
+When a triple whose object is a literal is ingested, `coerce_literal()` inspects that datatype and converts the value to the most appropriate Python / Neo4j type before writing it to the database.
+
+The conversion rules follow the natural mapping between XSD and Neo4j:
+
+* Numeric XSD types become Python `int` or `float`.
+* `xsd:boolean` becomes Python `bool`.
+* `xsd:string` / `xsd:normalizedString` become Python `str`.
+* Temporal XSD types become `neo4j.time.*` objects when the `neo4j` driver package is installed; otherwise they fall back to `str`.
+* Language-tagged literals are converted according to the `keep_lang_tag` flag.
+* Unknown / custom datatypes are handled according to the `keep_custom_data_types` flag.
+
+== Datatype Mapping Table
+
+|===
+| XSD Datatype(s) | Neo4j Property Type | Notes
+
+| `xsd:integer`, `xsd:long`, `xsd:int`, `xsd:short`, `xsd:byte`
+| Integer (`int`)
+| All standard signed integer variants
+
+| `xsd:nonNegativeInteger`, `xsd:positiveInteger`, `xsd:nonPositiveInteger`, `xsd:negativeInteger`
+| Integer (`int`)
+| Constraint is not enforced by Neo4j; value stored as-is
+
+| `xsd:unsignedLong`, `xsd:unsignedInt`, `xsd:unsignedShort`, `xsd:unsignedByte`
+| Integer (`int`)
+| Unsigned variants — all coerced to Python `int`
+
+| `xsd:float`, `xsd:double`
+| Float (`float`)
+| Direct cast to Python `float`
+
+| `xsd:decimal`
+| Float (`float`)
+| Python `Decimal` is converted to `float`
+
+| `xsd:boolean`
+| Boolean (`bool`)
+| rdflib's `toPython()` returns `True` / `False`
+
+| `xsd:string`, `xsd:normalizedString`
+| String (`str`)
+| Stored as a plain string
+
+| `xsd:date`
+| `neo4j.time.Date`
+| Falls back to `str` when the `neo4j` package is absent
+
+| `xsd:dateTime`, `xsd:dateTimeStamp`
+| `neo4j.time.DateTime`
+| Timezone offset preserved when present; falls back to `str`
+
+| `xsd:duration`, `xsd:dayTimeDuration`, `xsd:yearMonthDuration`
+| `neo4j.time.Duration`
+| Converted from `datetime.timedelta`; falls back to `str`
+
+| Language-tagged literal (e.g. `"hello"@en`)
+| String (`str`)
+| See <<lang-tags>> for `keep_lang_tag` / `language_filter` options
+
+| Unknown / custom datatype
+| String (`str`)
+| See <<custom-datatypes>> for `keep_custom_data_types` option
+|===
+
+[#lang-tags]
+== Language-Tagged Literals
+
+Language-tagged literals (e.g. `"Bonjour"@fr`) are plain strings at the RDF level; they carry no XSD datatype.
+The library offers two configuration options that affect how they are stored.
+
+=== keep_lang_tag
+
+When `keep_lang_tag=True`, the language code is appended to the value with an `@` separator, producing a string such as `"hello@en"`.
+When `keep_lang_tag=False` (the default), only the string value is kept.
+
+=== language_filter
+
+When `language_filter` is set to a BCP-47 language tag (e.g. `"en"`), any literal whose language tag does not match is *silently skipped* — the triple is not written to Neo4j.
+The comparison is case-insensitive.
+
+|===
+| Literal | `keep_lang_tag` | `language_filter` | Stored value
+
+| `"hello"@en`
+| `False`
+| _(none)_
+| `"hello"`
+
+| `"hello"@en`
+| `True`
+| _(none)_
+| `"hello@en"`
+
+| `"hello"@en`
+| `False`
+| `"fr"`
+| _(skipped)_
+
+| `"hello"@en`
+| `True`
+| `"en"`
+| `"hello@en"`
+|===
+
+[#custom-datatypes]
+== Custom and Unknown Datatypes
+
+RDF allows arbitrary datatype URIs beyond the XSD vocabulary (e.g. `"123-45-6789"^^<http://example.org/ssn>`).
+When such a literal is encountered, the behaviour depends on `keep_custom_data_types`:
+
+* `keep_custom_data_types=False` (default) — rdflib's `toPython()` is called and the result is stored.
+  For truly unknown types this typically returns a plain string with the lexical form.
+* `keep_custom_data_types=True` — the value is stored as `"lexicalForm^^datatypeURI"`, preserving the full round-trip information.
+
+== Configuration
+
+All three options are set on `Neo4jStoreConfig`:
+
+|===
+| Parameter | Type | Default | Description
+
+| `keep_lang_tag`
+| `bool`
+| `False`
+| Append the language code to language-tagged literals (`"value@lang"`)
+
+| `keep_custom_data_types`
+| `bool`
+| `False`
+| Preserve unknown datatypes as `"value^^<uri>"` strings
+
+| `language_filter`
+| `str` or `None`
+| `None`
+| Keep only literals whose language tag matches this BCP-47 code; skip all others
+|===
+
+== Python Example
+
+The following example imports a small Turtle document containing typed literals and shows what is written to Neo4j.
+
+.Turtle source (`data.ttl`)
+[source,turtle]
+----
+@prefix ex:  <http://example.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix schema: <http://schema.org/> .
+
+ex:Alice
+    a schema:Person ;
+    schema:name      "Alice"@en ;
+    schema:birthDate "1990-06-15"^^xsd:date ;
+    schema:height    "1.70"^^xsd:decimal ;
+    ex:active        "true"^^xsd:boolean ;
+    ex:score         "42"^^xsd:integer .
+----
+
+.Python import script
+[source,python]
+----
+from rdflib import ConjunctiveGraph, Namespace
+from rdflib_neo4j import HANDLE_VOCAB_URI_STRATEGY, Neo4jStoreConfig, Neo4jStore
+
+# Namespaces used in the Turtle file
+SCHEMA = Namespace("http://schema.org/")
+EX    = Namespace("http://example.org/")
+
+auth = {
+    "uri": "bolt://localhost:7687",
+    "database": "neo4j",
+    "user": "neo4j",
+    "pwd": "password",
+}
+
+config = Neo4jStoreConfig(
+    auth_data=auth,
+    custom_prefixes={"schema": SCHEMA, "ex": EX},
+    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.SHORTEN,
+    # Store English labels only; append the language tag to the stored value
+    keep_lang_tag=True,
+    language_filter="en",
+    # Preserve any custom datatype annotations
+    keep_custom_data_types=True,
+)
+
+store = Neo4jStore(config=config)
+g = ConjunctiveGraph(store=store)
+g.parse("data.ttl", format="ttl")
+g.close()
+----
+
+After the import, the Neo4j node for `ex:Alice` will have the following properties:
+
+|===
+| Property | Stored value | Neo4j type
+
+| `uri`
+| `"http://example.org/Alice"`
+| String
+
+| `name`
+| `"Alice@en"`
+| String (language tag appended)
+
+| `birthDate`
+| `neo4j.time.Date(1990, 6, 15)`
+| Date
+
+| `height`
+| `1.7`
+| Float
+
+| `active`
+| `true`
+| Boolean
+
+| `score`
+| `42`
+| Integer
+|===
+
+== See Also
+
+* xref:neo4jstoreconfig.adoc[Store Configuration] — full reference for all `Neo4jStoreConfig` parameters.
+* xref:examples.adoc[Examples] — end-to-end import examples.

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,29 +1,33 @@
 {
-    "name": "docs",
-    "version": "1.0.0",
-    "description": "",
-    "main": "server.js",
-    "scripts": {
-      "test": "echo \"Error: no test specified\" && exit 1",
-      "start": "npm run dev",
-      "dev": "node server.js & npm-watch preview",
-      "preview": "antora preview.yml",
-      "publish": "git push origin HEAD:publish"
-    },
-    "watch": {
-      "preview": {
-        "patterns": [
-          "modules"
-        ],
-        "extensions": "adoc"
-      }
-    },
-    "dependencies": {
-      "@antora/cli": "^3.1.1",
-      "@antora/site-generator-default": "^3.1.1",
-      "@neo4j-documentation/macros": "^1.0.0",
-      "@neo4j-documentation/remote-include": "^1.0.0",
-      "express": "^4.17.1",
-      "npm-watch": "^0.11.0"
+  "name": "docs",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "npm run dev",
+    "dev": "node server.js & npm-watch preview",
+    "preview": "antora preview.yml",
+    "publish": "git push origin HEAD:publish"
+  },
+  "watch": {
+    "preview": {
+      "patterns": [
+        "modules"
+      ],
+      "extensions": "adoc"
     }
+  },
+  "dependencies": {
+    "@antora/cli": "^3.1.1",
+    "@antora/site-generator-default": "^3.1.1",
+    "@neo4j-documentation/macros": "^1.0.0",
+    "@neo4j-documentation/remote-include": "^1.0.0",
+    "express": "^4.17.1",
+    "npm-watch": "^0.11.0"
+  },
+  "resolutions": {
+    "braces": "3.0.3",
+    "express": "4.20.0"
   }
+}

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -285,10 +285,10 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-body-parser@1.20.2:
-  version "1.20.2"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.2.tgz#6feb0e21c4724d06de7ff38da36dad4f57a747fd"
-  integrity sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==
+body-parser@1.20.3:
+  version "1.20.3"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.3.tgz#1953431221c6fb5cd63c4b36d53fab0928e548c6"
+  integrity sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==
   dependencies:
     bytes "3.1.2"
     content-type "~1.0.5"
@@ -298,10 +298,28 @@ body-parser@1.20.2:
     http-errors "2.0.0"
     iconv-lite "0.4.24"
     on-finished "2.4.1"
-    qs "6.11.0"
+    qs "6.13.0"
     raw-body "2.5.2"
     type-is "~1.6.18"
     unpipe "1.0.0"
+
+body-parser@~1.20.3:
+  version "1.20.5"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.5.tgz#303c8c34423d1d6fa799bc764e93c1e4dc6ebf64"
+  integrity sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==
+  dependencies:
+    bytes "~3.1.2"
+    content-type "~1.0.5"
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "~1.2.0"
+    http-errors "~2.0.1"
+    iconv-lite "~0.4.24"
+    on-finished "~2.4.1"
+    qs "~6.15.1"
+    raw-body "~2.5.3"
+    type-is "~1.6.18"
+    unpipe "~1.0.0"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -318,12 +336,12 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@~3.0, braces@~3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
-  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+braces@3.0.3, braces@~3.0, braces@~3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
-    fill-range "^7.0.1"
+    fill-range "^7.1.1"
 
 buffer-crc32@~0.2.3:
   version "0.2.13"
@@ -343,7 +361,7 @@ buffer@^6.0.3:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
-bytes@3.1.2:
+bytes@3.1.2, bytes@~3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
@@ -355,6 +373,14 @@ cache-directory@~2.0:
   dependencies:
     xdg-basedir "^3.0.0"
 
+call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
+  dependencies:
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
@@ -362,6 +388,14 @@ call-bind@^1.0.0, call-bind@^1.0.2:
   dependencies:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
+
+call-bound@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.4.tgz#238de935d2a2a692928c538c7ccfa91067fd062a"
+  integrity sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    get-intrinsic "^1.3.0"
 
 chokidar@^3.5.2:
   version "3.5.3"
@@ -422,7 +456,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-content-disposition@0.5.4:
+content-disposition@0.5.4, content-disposition@~0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
   integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
@@ -452,10 +486,20 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
 
+cookie-signature@~1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.7.tgz#ab5dd7ab757c54e60f37ef6550f481c426d10454"
+  integrity sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==
+
 cookie@0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
   integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
+
+cookie@~0.7.1:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
+  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
 core-util-is@~1.0.0:
   version "1.0.3"
@@ -511,12 +555,12 @@ define-properties@^1.1.4:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
 
-depd@2.0.0:
+depd@2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
-destroy@1.2.0:
+destroy@1.2.0, destroy@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
@@ -525,6 +569,15 @@ diff3@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/diff3/-/diff3-0.0.3.tgz#d4e5c3a4cdf4e5fe1211ab42e693fcb4321580fc"
   integrity sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==
+
+dunder-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
+  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
+  dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    es-errors "^1.3.0"
+    gopd "^1.2.0"
 
 duplexify@^3.6.0:
   version "3.7.1"
@@ -556,12 +609,34 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
 
+encodeurl@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
+  integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
+
 end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+es-define-property@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
+  integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
+
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
+es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
+  integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
+  dependencies:
+    es-errors "^1.3.0"
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -583,39 +658,76 @@ events@^3.3.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
-express@^4.17.1:
-  version "4.19.2"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.19.2.tgz#e25437827a3aa7f2a827bc8171bbbb664a356465"
-  integrity sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==
+express@4.20.0:
+  version "4.20.0"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.20.0.tgz#f1d08e591fcec770c07be4767af8eb9bcfd67c48"
+  integrity sha512-pLdae7I6QqShF5PnNTCVn4hI91Dx0Grkn2+IAsMTgMIKuQVte2dN9PeGSSAME2FR8anOhVA62QDIUaWVfEXVLw==
   dependencies:
     accepts "~1.3.8"
     array-flatten "1.1.1"
-    body-parser "1.20.2"
+    body-parser "1.20.3"
     content-disposition "0.5.4"
     content-type "~1.0.4"
     cookie "0.6.0"
     cookie-signature "1.0.6"
     debug "2.6.9"
     depd "2.0.0"
-    encodeurl "~1.0.2"
+    encodeurl "~2.0.0"
     escape-html "~1.0.3"
     etag "~1.8.1"
     finalhandler "1.2.0"
     fresh "0.5.2"
     http-errors "2.0.0"
-    merge-descriptors "1.0.1"
+    merge-descriptors "1.0.3"
     methods "~1.1.2"
     on-finished "2.4.1"
     parseurl "~1.3.3"
-    path-to-regexp "0.1.7"
+    path-to-regexp "0.1.10"
     proxy-addr "~2.0.7"
     qs "6.11.0"
     range-parser "~1.2.1"
     safe-buffer "5.2.1"
-    send "0.18.0"
-    serve-static "1.15.0"
+    send "0.19.0"
+    serve-static "1.16.0"
     setprototypeof "1.2.0"
     statuses "2.0.1"
+    type-is "~1.6.18"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
+
+express@^4.17.1:
+  version "4.22.1"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.22.1.tgz#1de23a09745a4fffdb39247b344bb5eaff382069"
+  integrity sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==
+  dependencies:
+    accepts "~1.3.8"
+    array-flatten "1.1.1"
+    body-parser "~1.20.3"
+    content-disposition "~0.5.4"
+    content-type "~1.0.4"
+    cookie "~0.7.1"
+    cookie-signature "~1.0.6"
+    debug "2.6.9"
+    depd "2.0.0"
+    encodeurl "~2.0.0"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    finalhandler "~1.3.1"
+    fresh "~0.5.2"
+    http-errors "~2.0.0"
+    merge-descriptors "1.0.3"
+    methods "~1.1.2"
+    on-finished "~2.4.1"
+    parseurl "~1.3.3"
+    path-to-regexp "~0.1.12"
+    proxy-addr "~2.0.7"
+    qs "~6.14.0"
+    range-parser "~1.2.1"
+    safe-buffer "5.2.1"
+    send "~0.19.0"
+    serve-static "~1.16.2"
+    setprototypeof "1.2.0"
+    statuses "~2.0.1"
     type-is "~1.6.18"
     utils-merge "1.0.1"
     vary "~1.1.2"
@@ -647,10 +759,10 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
-fill-range@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
-  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+fill-range@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
+  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
 
@@ -667,6 +779,19 @@ finalhandler@1.2.0:
     statuses "2.0.1"
     unpipe "~1.0.0"
 
+finalhandler@~1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.3.2.tgz#1ebc2228fc7673aac4a472c310cc05b77d852b88"
+  integrity sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==
+  dependencies:
+    debug "2.6.9"
+    encodeurl "~2.0.0"
+    escape-html "~1.0.3"
+    on-finished "~2.4.1"
+    parseurl "~1.3.3"
+    statuses "~2.0.2"
+    unpipe "~1.0.0"
+
 flush-write-stream@^1.0.2:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"
@@ -680,7 +805,7 @@ forwarded@0.2.0:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
   integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
 
-fresh@0.5.2:
+fresh@0.5.2, fresh@~0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
@@ -708,6 +833,11 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.1.tgz#d295644fed4505fc9cde952c37ee12b477a83d82"
@@ -717,6 +847,30 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@
     has "^1.0.3"
     has-proto "^1.0.1"
     has-symbols "^1.0.3"
+
+get-intrinsic@^1.2.5, get-intrinsic@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    function-bind "^1.1.2"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    math-intrinsics "^1.1.0"
+
+get-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
+  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
+  dependencies:
+    dunder-proto "^1.0.1"
+    es-object-atoms "^1.0.0"
 
 glob-parent@^3.1.0:
   version "3.1.0"
@@ -814,6 +968,11 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
+gopd@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
+  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
+
 graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.6:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
@@ -866,12 +1025,24 @@ has-symbols@^1.0.3:
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
+has-symbols@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
+  integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
+
 has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+hasown@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.3.tgz#5e5c2b15b60370a4c7930c383dfb76bf17bc403c"
+  integrity sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==
+  dependencies:
+    function-bind "^1.1.2"
 
 help-me@^4.0.1:
   version "4.2.0"
@@ -897,7 +1068,18 @@ http-errors@2.0.0:
     statuses "2.0.1"
     toidentifier "1.0.1"
 
-iconv-lite@0.4.24:
+http-errors@~2.0.0, http-errors@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.1.tgz#36d2f65bc909c8790018dd36fb4d93da6caae06b"
+  integrity sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==
+  dependencies:
+    depd "~2.0.0"
+    inherits "~2.0.4"
+    setprototypeof "~1.2.0"
+    statuses "~2.0.2"
+    toidentifier "~1.0.1"
+
+iconv-lite@0.4.24, iconv-lite@~0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -927,7 +1109,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -1078,15 +1260,20 @@ lodash.clonedeep@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
 
+math-intrinsics@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
+  integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
-merge-descriptors@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
-  integrity sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==
+merge-descriptors@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.3.tgz#d80319a65f3c7935351e5cfdac8f9318504dbed5"
+  integrity sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==
 
 methods@~1.1.2:
   version "1.1.2"
@@ -1216,6 +1403,11 @@ npm-watch@^0.11.0:
     nodemon "^2.0.7"
     through2 "^4.0.2"
 
+object-inspect@^1.13.3, object-inspect@^1.13.4:
+  version "1.13.4"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.4.tgz#8375265e21bc20d0fa582c22e1b13485d6e00213"
+  integrity sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==
+
 object-inspect@^1.9.0:
   version "1.12.3"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
@@ -1241,7 +1433,7 @@ on-exit-leak-free@^2.1.0:
   resolved "https://registry.yarnpkg.com/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz#5c703c968f7e7f851885f6459bf8a8a57edc9cc4"
   integrity sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w==
 
-on-finished@2.4.1:
+on-finished@2.4.1, on-finished@~2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
   integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
@@ -1282,10 +1474,15 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
-path-to-regexp@0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
-  integrity sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==
+path-to-regexp@0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.10.tgz#67e9108c5c0551b9e5326064387de4763c4d5f8b"
+  integrity sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==
+
+path-to-regexp@~0.1.12:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.13.tgz#9b22ec16bc3ab88d05a0c7e369869421401ab17d"
+  integrity sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==
 
 pend@~1.2.0:
   version "1.2.0"
@@ -1434,6 +1631,27 @@ qs@6.11.0:
   dependencies:
     side-channel "^1.0.4"
 
+qs@6.13.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.13.0.tgz#6ca3bd58439f7e245655798997787b0d88a51906"
+  integrity sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==
+  dependencies:
+    side-channel "^1.0.6"
+
+qs@~6.14.0:
+  version "6.14.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.2.tgz#b5634cf9d9ad9898e31fba3504e866e8efb6798c"
+  integrity sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==
+  dependencies:
+    side-channel "^1.1.0"
+
+qs@~6.15.1:
+  version "6.15.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.1.tgz#bdb55aed06bfac257a90c44a446a73fba5575c8f"
+  integrity sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==
+  dependencies:
+    side-channel "^1.1.0"
+
 queue@^4.2.1:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/queue/-/queue-4.5.1.tgz#6e4290a2d7e99dc75b34494431633fe5437b0dac"
@@ -1460,6 +1678,16 @@ raw-body@2.5.2:
     http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+raw-body@~2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.3.tgz#11c6650ee770a7de1b494f197927de0c923822e2"
+  integrity sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==
+  dependencies:
+    bytes "~3.1.2"
+    http-errors "~2.0.1"
+    iconv-lite "~0.4.24"
+    unpipe "~1.0.0"
 
 readable-stream@3, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.2"
@@ -1599,17 +1827,65 @@ send@0.18.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
-serve-static@1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.15.0.tgz#faaef08cffe0a1a62f60cad0c4e513cff0ac9540"
-  integrity sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==
+send@0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.19.0.tgz#bbc5a388c8ea6c048967049dbeac0e4a3f09d7f8"
+  integrity sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==
+  dependencies:
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "1.2.0"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    fresh "0.5.2"
+    http-errors "2.0.0"
+    mime "1.6.0"
+    ms "2.1.3"
+    on-finished "2.4.1"
+    range-parser "~1.2.1"
+    statuses "2.0.1"
+
+send@~0.19.0, send@~0.19.1:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.19.2.tgz#59bc0da1b4ea7ad42736fd642b1c4294e114ff29"
+  integrity sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==
+  dependencies:
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "1.2.0"
+    encodeurl "~2.0.0"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    fresh "~0.5.2"
+    http-errors "~2.0.1"
+    mime "1.6.0"
+    ms "2.1.3"
+    on-finished "~2.4.1"
+    range-parser "~1.2.1"
+    statuses "~2.0.2"
+
+serve-static@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.16.0.tgz#2bf4ed49f8af311b519c46f272bf6ac3baf38a92"
+  integrity sha512-pDLK8zwl2eKaYrs8mrPZBJua4hMplRWJ1tIFksVC3FtBEBnl8dxgeHtsaMS8DhS9i4fLObaon6ABoc4/hQGdPA==
   dependencies:
     encodeurl "~1.0.2"
     escape-html "~1.0.3"
     parseurl "~1.3.3"
     send "0.18.0"
 
-setprototypeof@1.2.0:
+serve-static@~1.16.2:
+  version "1.16.3"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.16.3.tgz#a97b74d955778583f3862a4f0b841eb4d5d78cf9"
+  integrity sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==
+  dependencies:
+    encodeurl "~2.0.0"
+    escape-html "~1.0.3"
+    parseurl "~1.3.3"
+    send "~0.19.1"
+
+setprototypeof@1.2.0, setprototypeof@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
@@ -1627,6 +1903,35 @@ should-proxy@~1.0:
   resolved "https://registry.yarnpkg.com/should-proxy/-/should-proxy-1.0.4.tgz#c805a501abf69539600634809e62fbf238ba35e4"
   integrity sha512-RPQhIndEIVUCjkfkQ6rs6sOR6pkxJWCNdxtfG5pP0RVgUYbK5911kLTF0TNcCC0G3YCGd492rMollFT2aTd9iQ==
 
+side-channel-list@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/side-channel-list/-/side-channel-list-1.0.1.tgz#c2e0b5a14a540aebee3bbc6c3f8666cc9b509127"
+  integrity sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.4"
+
+side-channel-map@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/side-channel-map/-/side-channel-map-1.0.1.tgz#d6bb6b37902c6fef5174e5f533fab4c732a26f42"
+  integrity sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==
+  dependencies:
+    call-bound "^1.0.2"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.5"
+    object-inspect "^1.13.3"
+
+side-channel-weakmap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz#11dda19d5368e40ce9ec2bdc1fb0ecbc0790ecea"
+  integrity sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==
+  dependencies:
+    call-bound "^1.0.2"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.5"
+    object-inspect "^1.13.3"
+    side-channel-map "^1.0.1"
+
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
@@ -1635,6 +1940,17 @@ side-channel@^1.0.4:
     call-bind "^1.0.0"
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
+
+side-channel@^1.0.6, side-channel@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.0.tgz#c3fcff9c4da932784873335ec9765fa94ff66bc9"
+  integrity sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.3"
+    side-channel-list "^1.0.0"
+    side-channel-map "^1.0.1"
+    side-channel-weakmap "^1.0.2"
 
 simple-concat@^1.0.0:
   version "1.0.1"
@@ -1678,6 +1994,11 @@ statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
+statuses@~2.0.1, statuses@~2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
+  integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
 
 stream-shift@^1.0.0:
   version "1.0.1"
@@ -1767,7 +2088,7 @@ to-through@^2.0.0:
   dependencies:
     through2 "^2.0.3"
 
-toidentifier@1.0.1:
+toidentifier@1.0.1, toidentifier@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==

--- a/rdflib_neo4j/Neo4jStore.py
+++ b/rdflib_neo4j/Neo4jStore.py
@@ -18,7 +18,7 @@ class Neo4jStore(Store):
 
     context_aware = True
 
-    def __init__(self, config: Neo4jStoreConfig, neo4j_driver: Driver = None):
+    def __init__(self, config: Neo4jStoreConfig, neo4j_driver: Driver | None = None):
         self.__open = False
         self.driver = neo4j_driver
         self.session = None

--- a/rdflib_neo4j/Neo4jStore.py
+++ b/rdflib_neo4j/Neo4jStore.py
@@ -257,12 +257,17 @@ class Neo4jStore(Store):
         self.__store_current_subject_rels()
 
     def __create_current_subject(self, subject):
-        return Neo4jTriple(uri=subject,
-                           prefixes={value: key for key, value in self.config.get_prefixes().items()},
-                           # Reversing the Prefix dictionary
-                           handle_vocab_uri_strategy=self.handle_vocab_uri_strategy,
-                           handle_multival_strategy=self.handle_multival_strategy,
-                           multival_props_names=self.multival_props_predicates)
+        return Neo4jTriple(
+            uri=subject,
+            prefixes={value: key for key, value in self.config.get_prefixes().items()},
+            # Reversing the Prefix dictionary
+            handle_vocab_uri_strategy=self.handle_vocab_uri_strategy,
+            handle_multival_strategy=self.handle_multival_strategy,
+            multival_props_names=self.multival_props_predicates,
+            keep_lang_tag=self.config.keep_lang_tag,
+            keep_custom_data_types=self.config.keep_custom_data_types,
+            language_filter=self.config.language_filter,
+        )
 
     def __check_current_subject(self, subject):
         """

--- a/rdflib_neo4j/Neo4jTriple.py
+++ b/rdflib_neo4j/Neo4jTriple.py
@@ -1,10 +1,12 @@
 from collections import defaultdict
-from decimal import Decimal
-from typing import Dict, Set, List
-from rdflib import Literal, URIRef, RDF
+from typing import Dict, List, Optional, Set
+
+from rdflib import Literal, RDF, URIRef
 from rdflib.term import Node
+
+from rdflib_neo4j.config.const import HANDLE_MULTIVAL_STRATEGY, HANDLE_VOCAB_URI_STRATEGY
+from rdflib_neo4j.datatypes import coerce_literal
 from rdflib_neo4j.utils import handle_vocab_uri
-from rdflib_neo4j.config.const import HANDLE_VOCAB_URI_STRATEGY, HANDLE_MULTIVAL_STRATEGY
 
 
 class Neo4jTriple:
@@ -22,7 +24,10 @@ class Neo4jTriple:
                  handle_vocab_uri_strategy: HANDLE_VOCAB_URI_STRATEGY,
                  handle_multival_strategy: HANDLE_MULTIVAL_STRATEGY,
                  multival_props_names: List[str],
-                 prefixes: Dict[str, str]):
+                 prefixes: Dict[str, str],
+                 keep_lang_tag: bool = False,
+                 keep_custom_data_types: bool = False,
+                 language_filter: Optional[str] = None):
         """
         Constructor for Neo4jTriple.
 
@@ -42,6 +47,9 @@ class Neo4jTriple:
         self.handle_multival_strategy = handle_multival_strategy
         self.multival_props_names = multival_props_names
         self.prefixes = prefixes
+        self.keep_lang_tag = keep_lang_tag
+        self.keep_custom_data_types = keep_custom_data_types
+        self.language_filter = language_filter
 
     def add_label(self, label: str):
         """
@@ -155,8 +163,14 @@ class Neo4jTriple:
 
         # Getting a property
         if isinstance(object, Literal):
-            # Neo4j Python driver does not support decimal params
-            value = float(object.toPython()) if type(object.toPython()) == Decimal else object.toPython()
+            value = coerce_literal(
+                object,
+                keep_lang_tag=self.keep_lang_tag,
+                keep_custom_data_types=self.keep_custom_data_types,
+                language_filter=self.language_filter,
+            )
+            if value is None:
+                return  # language_filter skipped this literal
             prop_name = self.handle_vocab_uri(mappings, predicate)
 
             # If at least a name is defined and the predicate is one of the properties defined by the user

--- a/rdflib_neo4j/config/Neo4jStoreConfig.py
+++ b/rdflib_neo4j/config/Neo4jStoreConfig.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 from rdflib import Namespace, URIRef
 from rdflib_neo4j.config.const import (
     DEFAULT_PREFIXES,
@@ -38,7 +38,10 @@ class Neo4jStoreConfig:
             batch_size=5000,
             handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.SHORTEN,
             handle_multival_strategy=HANDLE_MULTIVAL_STRATEGY.OVERWRITE,
-            multival_props_names: List[Tuple[str, str]] = []
+            multival_props_names: List[Tuple[str, str]] = [],
+            keep_lang_tag: bool = False,
+            keep_custom_data_types: bool = False,
+            language_filter: Optional[str] = None,
     ):
         self.default_prefixes = DEFAULT_PREFIXES
         self.auth_data = auth_data
@@ -53,6 +56,9 @@ class Neo4jStoreConfig:
         self.multival_props_names = []
         for prop_name in multival_props_names:
             self.set_multival_prop_name(prefix_name=prop_name[0], prop_name=prop_name[1])
+        self.keep_lang_tag = keep_lang_tag
+        self.keep_custom_data_types = keep_custom_data_types
+        self.language_filter = language_filter
 
     def set_handle_vocab_uri_strategy(self, val: HANDLE_VOCAB_URI_STRATEGY):
         """

--- a/rdflib_neo4j/datatypes.py
+++ b/rdflib_neo4j/datatypes.py
@@ -1,0 +1,111 @@
+import datetime
+from decimal import Decimal
+from typing import Any, Optional
+
+from rdflib import Literal, XSD
+
+try:
+    from neo4j.time import Date, DateTime, Duration
+except ImportError:
+    Date = DateTime = Duration = None
+
+
+def coerce_literal(
+    literal: Literal,
+    keep_lang_tag: bool = False,
+    keep_custom_data_types: bool = False,
+    language_filter: Optional[str] = None,
+) -> Any:
+    """Convert an rdflib Literal to the appropriate Python/Neo4j type.
+
+    Returns None if the literal should be skipped (language_filter mismatch).
+    """
+
+    # Language filter: skip literals whose lang tag doesn't match
+    if language_filter and literal.language and literal.language.lower() != language_filter.lower():
+        return None  # signal to caller to skip this literal
+
+    # Language-tagged literals
+    if literal.language:
+        if keep_lang_tag:
+            return f"{str(literal)}@{literal.language}"
+        return str(literal)
+
+    # Typed literals
+    datatype = literal.datatype
+
+    if datatype in (
+        XSD.integer,
+        XSD.long,
+        XSD.int,
+        XSD.short,
+        XSD.byte,
+        XSD.nonNegativeInteger,
+        XSD.positiveInteger,
+        XSD.nonPositiveInteger,
+        XSD.negativeInteger,
+        XSD.unsignedLong,
+        XSD.unsignedInt,
+        XSD.unsignedShort,
+        XSD.unsignedByte,
+    ):
+        return int(literal)
+
+    if datatype in (XSD.float, XSD.double):
+        return float(literal)
+
+    if datatype == XSD.decimal:
+        v = literal.toPython()
+        return float(v) if isinstance(v, Decimal) else float(v)
+
+    if datatype == XSD.boolean:
+        return literal.toPython()  # rdflib returns bool
+
+    if datatype in (XSD.string, XSD.normalizedString):
+        return str(literal)
+
+    if datatype == XSD.date:
+        if Date is not None:
+            d = literal.toPython()  # returns datetime.date
+            return Date(d.year, d.month, d.day)
+        return str(literal)
+
+    if datatype in (XSD.dateTime, XSD.dateTimeStamp):
+        if DateTime is not None:
+            dt = literal.toPython()  # returns datetime.datetime
+            if dt.tzinfo is not None:
+                return DateTime(
+                    dt.year,
+                    dt.month,
+                    dt.day,
+                    dt.hour,
+                    dt.minute,
+                    dt.second,
+                    dt.microsecond * 1000,
+                    dt.utcoffset().total_seconds(),
+                )
+            return DateTime(
+                dt.year,
+                dt.month,
+                dt.day,
+                dt.hour,
+                dt.minute,
+                dt.second,
+                dt.microsecond * 1000,
+            )
+        return str(literal)
+
+    if datatype in (XSD.duration, XSD.dayTimeDuration, XSD.yearMonthDuration):
+        if Duration is not None:
+            td = literal.toPython()  # returns datetime.timedelta
+            if isinstance(td, datetime.timedelta):
+                return Duration(seconds=int(td.total_seconds()))
+        return str(literal)
+
+    # Unknown/custom datatype
+    if datatype and keep_custom_data_types:
+        return f"{str(literal)}^^{str(datatype)}"
+
+    # Fall back: use toPython, convert Decimal to float
+    v = literal.toPython()
+    return float(v) if isinstance(v, Decimal) else v

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-setuptools==68.1.2
+setuptools==70.0.0
 rdflib==7.0.0
 neo4j==5.11.0
 testcontainers~=3.7.1

--- a/test/unit/test_datatypes.py
+++ b/test/unit/test_datatypes.py
@@ -1,0 +1,163 @@
+"""Unit tests for rdflib_neo4j.datatypes.coerce_literal — no Neo4j connection needed."""
+import pytest
+from rdflib import Literal, XSD
+
+from rdflib_neo4j.datatypes import coerce_literal
+
+
+# ---------------------------------------------------------------------------
+# Numeric types
+# ---------------------------------------------------------------------------
+
+def test_integer():
+    assert coerce_literal(Literal("42", datatype=XSD.integer)) == 42
+    assert isinstance(coerce_literal(Literal("42", datatype=XSD.integer)), int)
+
+
+def test_long():
+    assert coerce_literal(Literal("9999999999", datatype=XSD.long)) == 9999999999
+
+
+def test_float():
+    result = coerce_literal(Literal("3.14", datatype=XSD.float))
+    assert isinstance(result, float)
+    assert abs(result - 3.14) < 1e-6
+
+
+def test_double():
+    result = coerce_literal(Literal("2.718", datatype=XSD.double))
+    assert isinstance(result, float)
+
+
+def test_decimal():
+    result = coerce_literal(Literal("1.5", datatype=XSD.decimal))
+    assert isinstance(result, float)
+    assert result == 1.5
+
+
+# ---------------------------------------------------------------------------
+# Boolean
+# ---------------------------------------------------------------------------
+
+def test_boolean_true():
+    assert coerce_literal(Literal("true", datatype=XSD.boolean)) is True
+
+
+def test_boolean_false():
+    assert coerce_literal(Literal("false", datatype=XSD.boolean)) is False
+
+
+# ---------------------------------------------------------------------------
+# String types
+# ---------------------------------------------------------------------------
+
+def test_string():
+    result = coerce_literal(Literal("hello", datatype=XSD.string))
+    assert result == "hello"
+    assert isinstance(result, str)
+
+
+def test_normalized_string():
+    result = coerce_literal(Literal("hello world", datatype=XSD.normalizedString))
+    assert result == "hello world"
+
+
+# ---------------------------------------------------------------------------
+# Temporal types (requires neo4j package)
+# ---------------------------------------------------------------------------
+
+neo4j_time = pytest.importorskip("neo4j.time")
+
+
+def test_date():
+    from neo4j.time import Date
+    result = coerce_literal(Literal("2024-01-15", datatype=XSD.date))
+    assert isinstance(result, Date)
+    assert result == Date(2024, 1, 15)
+
+
+def test_datetime_naive():
+    from neo4j.time import DateTime
+    result = coerce_literal(Literal("2024-01-15T10:30:00", datatype=XSD.dateTime))
+    assert isinstance(result, DateTime)
+    assert result.year == 2024
+    assert result.month == 1
+    assert result.day == 15
+    assert result.hour == 10
+    assert result.minute == 30
+    assert result.second == 0
+
+
+def test_datetime_with_timezone():
+    from neo4j.time import DateTime
+    result = coerce_literal(Literal("2024-01-15T10:30:00+02:00", datatype=XSD.dateTime))
+    assert isinstance(result, DateTime)
+    assert result.year == 2024
+
+
+def test_duration():
+    from neo4j.time import Duration
+    # P1DT1H = 1 day + 1 hour = 90000 seconds
+    result = coerce_literal(Literal("P1DT1H", datatype=XSD.duration))
+    assert isinstance(result, Duration)
+
+
+# ---------------------------------------------------------------------------
+# Language-tagged literals
+# ---------------------------------------------------------------------------
+
+def test_lang_tag_keep():
+    lit = Literal("hello", lang="en")
+    result = coerce_literal(lit, keep_lang_tag=True)
+    assert result == "hello@en"
+
+
+def test_lang_tag_no_keep():
+    lit = Literal("hello", lang="en")
+    result = coerce_literal(lit, keep_lang_tag=False)
+    assert result == "hello"
+
+
+def test_language_filter_match():
+    lit = Literal("hello", lang="en")
+    result = coerce_literal(lit, language_filter="en")
+    assert result == "hello"
+
+
+def test_language_filter_match_keep_tag():
+    lit = Literal("hello", lang="en")
+    result = coerce_literal(lit, keep_lang_tag=True, language_filter="en")
+    assert result == "hello@en"
+
+
+def test_language_filter_no_match():
+    lit = Literal("hello", lang="en")
+    result = coerce_literal(lit, language_filter="fr")
+    assert result is None
+
+
+def test_language_filter_case_insensitive():
+    lit = Literal("hello", lang="EN")
+    result = coerce_literal(lit, language_filter="en")
+    assert result == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Custom datatypes
+# ---------------------------------------------------------------------------
+
+def test_custom_datatype_keep():
+    from rdflib import URIRef
+    dt = URIRef("http://example.org/mytype")
+    lit = Literal("myvalue", datatype=dt)
+    result = coerce_literal(lit, keep_custom_data_types=True)
+    assert result == "myvalue^^http://example.org/mytype"
+
+
+def test_custom_datatype_no_keep():
+    from rdflib import URIRef
+    dt = URIRef("http://example.org/mytype")
+    lit = Literal("myvalue", datatype=dt)
+    result = coerce_literal(lit, keep_custom_data_types=False)
+    # Falls back to toPython() which returns a string for unknown datatypes
+    assert "myvalue" in str(result)


### PR DESCRIPTION
## Summary
- New `rdflib_neo4j/datatypes.py` with `coerce_literal()` function
- `xsd:date` → `neo4j.time.Date`, `xsd:dateTime` → `neo4j.time.DateTime`, `xsd:duration` → `neo4j.time.Duration`
- `xsd:integer/long/int/short` → `int`, `xsd:float/double` → `float`, `xsd:decimal` → `float`, `xsd:boolean` → `bool`
- Language-tagged literals: `keep_lang_tag=True` stores `"value@en"`, `False` stores `"value"`
- `language_filter` skips literals whose lang tag doesn't match
- Custom datatypes: `keep_custom_data_types=True` stores `"value^^<type>"`, else plain value
- New config flags: `keep_lang_tag`, `keep_custom_data_types`, `language_filter` on `Neo4jStoreConfig`
- Replaces inline `toPython()` + Decimal conversion in `Neo4jTriple.parse_triple()`
- New docs page `docs/modules/ROOT/pages/datatype-coercion.adoc` with full mapping table, configuration reference, and a Turtle + Python example showing what ends up in Neo4j

Note: `OffsetDateTime` read path waits for n10s `fix/166-timezone-datetime`. Write path is complete.

## Test plan
- [ ] 21 unit tests in `test/unit/test_datatypes.py` — all passing, no Neo4j required
- [ ] All XSD numeric, boolean, string, temporal, lang-tag, and custom-datatype cases covered

## Documentation
- `docs/modules/ROOT/pages/datatype-coercion.adoc` — new page covering the full XSD→Neo4j mapping table, language-tag options, custom datatype handling, and an end-to-end Python + Turtle example
- `docs/modules/ROOT/nav.adoc` — added link to new page between "Store Configuration" and "Examples"

Closes #52