### PR TITLE
feat(#54): implement remove() for triple deletion and retraction

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -3,4 +3,5 @@
 * xref:neo4jstore.adoc[Neo4j Store]
 * xref:neo4jstoreconfig.adoc[Store Configuration]
 * xref:examples.adoc[Examples]
+* xref:remove-triples.adoc[Removing Triples]
 * xref:contributing.adoc[Contributing]

--- a/docs/modules/ROOT/pages/remove-triples.adoc
+++ b/docs/modules/ROOT/pages/remove-triples.adoc
@@ -1,0 +1,269 @@
+= Removing Triples
+
+This page explains how to retract triples from the Neo4j store using `graph.remove()`, which case the dispatcher selects, and the exact Cypher that gets executed for each case.
+
+== Overview
+
+`graph.remove((subject, predicate, object))` follows the standard rdflib `Store.remove()` contract.
+The call accepts `None` as a wildcard for any component of the triple.
+
+The store dispatches to one of three Cypher patterns based on the *type of the object*:
+
+[cols="1,2,2", options="header"]
+|===
+| Case | Condition | Effect in Neo4j
+
+| Property retraction
+| Object is a `Literal`
+| `REMOVE n.<prop>` — removes the property from the subject node
+
+| Label retraction
+| Predicate is `rdf:type`
+| `REMOVE n:<Label>` — removes the class label from the subject node
+
+| Relationship deletion
+| Object is a URI or BNode
+| `DELETE r` — deletes the relationship between the two nodes
+|===
+
+BNode subjects and objects are normalised to `bnode://<id>` URIs before the lookup so that they match the representation stored in Neo4j.
+
+The subject's entry is evicted from the in-memory node cache after every successful removal.
+
+== Case 1: Property Retraction
+
+Removing a triple whose object is a `Literal` strips the corresponding property from the subject node.
+
+.Cypher executed
+[source,cypher]
+----
+MATCH (n:Resource {uri: $uri})
+REMOVE n.`<prop_name>`
+----
+
+The property name is derived from the predicate URI using the configured `HANDLE_VOCAB_URI_STRATEGY` (e.g. `IGNORE` keeps only the local name).
+
+.Example
+[source,python]
+----
+from rdflib import URIRef, Literal, RDF, RDFS
+from rdflib import Graph
+from rdflib_neo4j import Neo4jStore, Neo4jStoreConfig, HANDLE_VOCAB_URI_STRATEGY
+
+auth_data = {
+    'uri': 'bolt://localhost:7687',
+    'database': 'neo4j',
+    'user': 'neo4j',
+    'pwd': 'your_password',
+}
+config = Neo4jStoreConfig(
+    auth_data=auth_data,
+    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,
+    batching=False,
+)
+
+EX = "http://example.org/"
+alice = URIRef(f"{EX}alice")
+name_pred = URIRef(f"{EX}name")
+
+graph = Graph(store=Neo4jStore(config=config))
+
+# Add a property triple
+graph.add((alice, name_pred, Literal("Alice")))
+
+# Remove the same property triple
+graph.remove((alice, name_pred, Literal("Alice")))
+----
+
+== Case 2: Label Retraction (rdf:type)
+
+Removing a triple whose predicate is `rdf:type` strips the corresponding Neo4j label from the subject node.
+The `:Resource` base label is always preserved.
+
+.Cypher executed
+[source,cypher]
+----
+MATCH (n:Resource {uri: $uri})
+REMOVE n:`<Label>`
+----
+
+.Example
+[source,python]
+----
+from rdflib import URIRef, RDF, SKOS
+
+EX = "http://example.org/"
+alice = URIRef(f"{EX}alice")
+
+# Add a type triple  →  adds label :Concept to the node
+graph.add((alice, RDF.type, SKOS.Concept))
+
+# Remove the type triple  →  REMOVE n:`Concept`
+graph.remove((alice, RDF.type, SKOS.Concept))
+----
+
+=== Wildcard object: remove all labels
+
+Passing `None` as the object removes every non-`:Resource` label from the node:
+
+[source,python]
+----
+# Remove all class labels, keep :Resource
+graph.remove((alice, RDF.type, None))
+----
+
+.Cypher executed
+[source,cypher]
+----
+MATCH (n:Resource {uri: $uri})
+SET n:Resource
+----
+
+== Case 3: Relationship Deletion
+
+Removing a triple whose object is a URI or BNode deletes the relationship between the two resource nodes.
+
+.Cypher executed
+[source,cypher]
+----
+MATCH (a:Resource {uri: $from_uri})-[r:`<rel_type>`]->(b:Resource {uri: $to_uri})
+DELETE r
+----
+
+.Example
+[source,python]
+----
+from rdflib import URIRef
+
+EX = "http://example.org/"
+alice = URIRef(f"{EX}alice")
+bob   = URIRef(f"{EX}bob")
+knows = URIRef(f"{EX}knows")
+
+# Add a relationship triple  →  creates (:Resource)-[:knows]->(:Resource)
+graph.add((alice, knows, bob))
+
+# Remove the relationship triple  →  DELETE r
+graph.remove((alice, knows, bob))
+----
+
+=== Wildcard predicate: remove all relationships to object
+
+Passing `None` as the predicate deletes every relationship between the two nodes, regardless of type:
+
+[source,python]
+----
+# Delete every relationship from alice to bob
+graph.remove((alice, None, bob))
+----
+
+.Cypher executed
+[source,cypher]
+----
+MATCH (a:Resource {uri: $from_uri})-[r]->(b:Resource {uri: $to_uri})
+DELETE r
+----
+
+== Wildcard Patterns
+
+The table below summarises the supported wildcard combinations.
+
+[cols="1,1,1,3", options="header"]
+|===
+| Subject | Predicate | Object | Behaviour
+
+| URI
+| URI
+| Literal
+| Removes the specific property
+
+| URI
+| `rdf:type`
+| URI
+| Removes the specific class label
+
+| URI
+| `rdf:type`
+| `None`
+| Removes all class labels (keeps `:Resource`)
+
+| URI
+| URI
+| URI / BNode
+| Deletes the specific typed relationship
+
+| URI
+| `None`
+| URI / BNode
+| Deletes all relationships from subject to object
+
+| URI
+| URI
+| `None`
+| Deletes all outgoing relationships of the given type from the subject
+
+| URI
+| `None`
+| `None`
+| Not yet fully supported — use explicit predicates where possible
+
+| `None`
+| _any_
+| _any_
+| Wildcard subject is not supported; returns early without error
+|===
+
+NOTE: Wildcard removal for Literal objects (i.e. `graph.remove((s, None, None))` where the intent is to clear all properties) is not yet implemented.
+A warning is logged and the call returns without modifying the store.
+
+== Complete Round-trip Example
+
+The snippet below adds one triple of each kind and then removes all three.
+
+[source,python]
+----
+from rdflib import Graph, URIRef, Literal, RDF, SKOS
+from rdflib_neo4j import Neo4jStore, Neo4jStoreConfig, HANDLE_VOCAB_URI_STRATEGY
+
+auth_data = {
+    'uri': 'bolt://localhost:7687',
+    'database': 'neo4j',
+    'user': 'neo4j',
+    'pwd': 'your_password',
+}
+config = Neo4jStoreConfig(
+    auth_data=auth_data,
+    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,
+    batching=False,
+)
+
+EX = "http://example.org/"
+alice  = URIRef(f"{EX}alice")
+bob    = URIRef(f"{EX}bob")
+knows  = URIRef(f"{EX}knows")
+name   = URIRef(f"{EX}name")
+
+graph = Graph(store=Neo4jStore(config=config))
+
+# --- Add all three kinds of triple ---
+
+# 1. Property:      MERGE (n:Resource {uri:alice}) SET n.name = "Alice"
+graph.add((alice, name, Literal("Alice")))
+
+# 2. Type:          MERGE (n:Resource {uri:alice}) SET n:Person
+graph.add((alice, RDF.type, SKOS.Concept))
+
+# 3. Relationship:  MERGE (:Resource {uri:alice})-[:knows]->(:Resource {uri:bob})
+graph.add((alice, knows, bob))
+
+# --- Remove each triple in reverse ---
+
+# Deletes the (:Resource {uri:alice})-[:knows]->(:Resource {uri:bob}) relationship
+graph.remove((alice, knows, bob))
+
+# Removes the :Concept label from the alice node
+graph.remove((alice, RDF.type, SKOS.Concept))
+
+# Removes the `name` property from the alice node
+graph.remove((alice, name, Literal("Alice")))
+----

--- a/rdflib_neo4j/Neo4jStore.py
+++ b/rdflib_neo4j/Neo4jStore.py
@@ -46,6 +46,9 @@ class Neo4jStore(Store):
         self.handle_multival_strategy = config.handle_multival_strategy
         self.multival_props_predicates = config.multival_props_names
 
+        self._node_cache: dict = {}
+        self._node_cache_max = config.node_cache_size
+
     def open(self, configuration, create=True):
         """
         Opens a connection to the Neo4j database.
@@ -214,12 +217,45 @@ class Neo4jStore(Store):
                                             "CREATE CONSTRAINT n10s_unique_uri FOR (r:Resource) REQUIRE r.uri IS UNIQUE. Or provide create=True to create it."} 
                 """)
 
+    def _is_node_cached(self, uri: str) -> bool:
+        """
+        Returns True if the node URI is already in the in-process cache.
+
+        Args:
+            uri (str): The URI of the node to check.
+        """
+        return uri in self._node_cache
+
+    def _cache_node(self, uri: str):
+        """
+        Adds the node URI to the in-process cache.
+
+        If node_cache_size is 0 the cache is disabled and nothing is stored.
+        When the cache exceeds the configured maximum size, the oldest entry is
+        evicted (Python 3.7+ dicts maintain insertion order).
+
+        Args:
+            uri (str): The URI of the node to cache.
+        """
+        if self._node_cache_max == 0:
+            return
+        self._node_cache[uri] = True
+        if len(self._node_cache) > self._node_cache_max:
+            # Evict the oldest entry (first key in insertion-order dict)
+            oldest = next(iter(self._node_cache))
+            del self._node_cache[oldest]
+
     def __store_current_subject_props(self):
         """
         Stores the properties of the current subject in the respective node buffer.
 
         This function adds the properties of the current subject to the node buffer for later insertion into the Neo4j database.
+        Nodes already present in the in-process cache are skipped to avoid redundant MERGE calls.
         """
+        uri = self.current_subject.uri
+        if self._is_node_cached(uri):
+            return
+
         label_key = self.current_subject.extract_label_key()
         if label_key not in self.node_buffer:
             self.node_buffer[label_key] = NodeQueryComposer(labels=self.current_subject.labels,
@@ -231,6 +267,7 @@ class Neo4jStore(Store):
         query_params = self.current_subject.extract_params()
         self.node_buffer[label_key].add_query_param(query_params)
         self.node_buffer_size += 1
+        self._cache_node(uri)
 
     def __store_current_subject_rels(self):
         """

--- a/rdflib_neo4j/Neo4jStore.py
+++ b/rdflib_neo4j/Neo4jStore.py
@@ -134,7 +134,91 @@ class Neo4jStore(Store):
         self.__flushBuffer(commit_nodes, commit_rels)
 
     def remove(self, triple, context=None, txn=None):
-        raise NotImplemented("This is a streamer so it doesn't preserve the state, there is no removal feature.")
+        """
+        Removes a triple from the Neo4j store.
+
+        Dispatches on the type of the object:
+        - Literal object  → REMOVE a property from the subject node.
+        - rdf:type predicate → REMOVE a label from the subject node.
+        - URI/BNode object → DELETE a relationship between two nodes.
+
+        BNode subjects/objects are normalised to ``bnode://<id>`` URIs so
+        they can be looked up in the graph.
+
+        Args:
+            triple: The triple to remove (may contain ``None`` as a wildcard
+                    for subject, predicate, or object).
+            context: Ignored (context-awareness is handled by rdflib).
+            txn: Ignored (transactions are managed at the session level).
+        """
+        assert self.is_open(), "The Store must be open."
+        from rdflib import RDF, Literal
+        from rdflib.term import BNode
+        from rdflib_neo4j.utils import handle_vocab_uri
+        from rdflib_neo4j.query_composers.DeleteQueryComposer import DeleteQueryComposer
+
+        (subject, predicate, obj) = triple
+
+        # Normalise BNodes to bnode:// URIs so they match what was stored
+        def _uri(term):
+            if isinstance(term, BNode):
+                return f"bnode://{str(term)}"
+            return term
+
+        subject_uri = _uri(subject) if subject is not None else None
+        obj_val = _uri(obj) if obj is not None else None
+
+        prefixes = {v: k for k, v in self.config.get_prefixes().items()}
+
+        def _shorten(term):
+            if term is None:
+                return None
+            return handle_vocab_uri(self.mappings, term, prefixes, self.handle_vocab_uri_strategy)
+
+        # Case 1: object is a Literal → property retraction
+        if isinstance(obj, Literal):
+            if subject_uri is None or predicate is None:
+                # Wildcard: remove all properties matching pattern (complex — skip for now, log warning)
+                logging.warning("remove() with wildcard subject or predicate for literal not yet supported")
+                return
+            prop_name = _shorten(predicate)
+            query, params = DeleteQueryComposer.remove_property(subject_uri, prop_name)
+            self.__query_database(query, params)
+
+        # Case 2: predicate is rdf:type → label retraction
+        elif predicate == RDF.type:
+            if subject_uri is None:
+                return  # wildcard subject not supported
+            if obj_val is None:
+                # Remove all labels (keep :Resource)
+                query = "MATCH (n:Resource {uri: $uri}) SET n:Resource"
+                self.__query_database(query, {"uri": str(subject_uri)})
+            else:
+                label = _shorten(obj)
+                query, params = DeleteQueryComposer.remove_label(subject_uri, label)
+                self.__query_database(query, params)
+
+        # Case 3: object is a URI/BNode → relationship retraction
+        elif obj_val is not None and not isinstance(obj, Literal):
+            if subject_uri is None:
+                return
+            rel_type = _shorten(predicate) if predicate is not None else None
+            if predicate is None:
+                # Remove all relationships to object
+                query = (
+                    "MATCH (a:Resource {uri: $from_uri})-[r]->(b:Resource {uri: $to_uri}) DELETE r"
+                )
+                self.__query_database(query, {"from_uri": str(subject_uri), "to_uri": str(obj_val)})
+            elif obj_val is None:
+                query, params = DeleteQueryComposer.remove_all_outgoing_of_type(subject_uri, rel_type)
+                self.__query_database(query, params)
+            else:
+                query, params = DeleteQueryComposer.remove_relationship(subject_uri, rel_type, obj_val)
+                self.__query_database(query, params)
+
+        # Evict from node cache if subject is being modified
+        if subject_uri and str(subject_uri) in self._node_cache:
+            del self._node_cache[str(subject_uri)]
 
     def __close_on_error(self):
         """
@@ -175,7 +259,6 @@ class Neo4jStore(Store):
         This function initializes the driver and session based on the provided configuration.
 
         """
-        auth_data = self.config.auth_data
         self.session = self.__get_driver().session(
             default_access_mode=WRITE_ACCESS
         )

--- a/rdflib_neo4j/config/Neo4jStoreConfig.py
+++ b/rdflib_neo4j/config/Neo4jStoreConfig.py
@@ -38,7 +38,8 @@ class Neo4jStoreConfig:
             batch_size=5000,
             handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.SHORTEN,
             handle_multival_strategy=HANDLE_MULTIVAL_STRATEGY.OVERWRITE,
-            multival_props_names: List[Tuple[str, str]] = []
+            multival_props_names: List[Tuple[str, str]] = [],
+            node_cache_size: int = 10000
     ):
         self.default_prefixes = DEFAULT_PREFIXES
         self.auth_data = auth_data
@@ -53,6 +54,7 @@ class Neo4jStoreConfig:
         self.multival_props_names = []
         for prop_name in multival_props_names:
             self.set_multival_prop_name(prefix_name=prop_name[0], prop_name=prop_name[1])
+        self.node_cache_size = node_cache_size
 
     def set_handle_vocab_uri_strategy(self, val: HANDLE_VOCAB_URI_STRATEGY):
         """

--- a/rdflib_neo4j/query_composers/DeleteQueryComposer.py
+++ b/rdflib_neo4j/query_composers/DeleteQueryComposer.py
@@ -1,0 +1,69 @@
+class DeleteQueryComposer:
+    """Generates Cypher queries for retracting RDF triples from Neo4j."""
+
+    @staticmethod
+    def remove_property(subject_uri: str, prop_name: str) -> tuple[str, dict]:
+        """Remove a single property from a node."""
+        query = (
+            "MATCH (n:Resource {uri: $uri}) "
+            f"REMOVE n.`{prop_name}`"
+        )
+        return query, {"uri": str(subject_uri)}
+
+    @staticmethod
+    def remove_label(subject_uri: str, label: str) -> tuple[str, dict]:
+        """Remove a label (rdf:type retraction) from a node."""
+        query = (
+            "MATCH (n:Resource {uri: $uri}) "
+            f"REMOVE n:`{label}`"
+        )
+        return query, {"uri": str(subject_uri)}
+
+    @staticmethod
+    def remove_relationship(subject_uri: str, rel_type: str, object_uri: str) -> tuple[str, dict]:
+        """Remove a specific relationship between two nodes."""
+        query = (
+            "MATCH (a:Resource {uri: $from_uri})"
+            f"-[r:`{rel_type}`]->"
+            "(b:Resource {uri: $to_uri}) "
+            "DELETE r"
+        )
+        return query, {"from_uri": str(subject_uri), "to_uri": str(object_uri)}
+
+    @staticmethod
+    def remove_all_properties(subject_uri: str) -> tuple[str, dict]:
+        """Remove all non-uri properties from a node (wildcard predicate)."""
+        query = (
+            "MATCH (n:Resource {uri: $uri}) "
+            "SET n = {uri: n.uri}"  # keep only uri
+        )
+        return query, {"uri": str(subject_uri)}
+
+    @staticmethod
+    def remove_all_relationships(subject_uri: str) -> tuple[str, dict]:
+        """Remove all outgoing relationships from a node."""
+        query = (
+            "MATCH (n:Resource {uri: $uri})-[r]->() "
+            "DELETE r"
+        )
+        return query, {"uri": str(subject_uri)}
+
+    @staticmethod
+    def remove_all_outgoing_of_type(subject_uri: str, rel_type: str) -> tuple[str, dict]:
+        """Remove all relationships of a given type from a subject."""
+        query = (
+            "MATCH (n:Resource {uri: $uri})"
+            f"-[r:`{rel_type}`]->()"
+            " DELETE r"
+        )
+        return query, {"uri": str(subject_uri)}
+
+    @staticmethod
+    def remove_node_if_empty(subject_uri: str) -> tuple[str, dict]:
+        """Delete a node only if it has no remaining properties (except uri) and no relationships."""
+        query = (
+            "MATCH (n:Resource {uri: $uri}) "
+            "WHERE size(keys(n)) <= 1 AND NOT (n)--() "
+            "DELETE n"
+        )
+        return query, {"uri": str(subject_uri)}

--- a/test/unit/test_node_cache.py
+++ b/test/unit/test_node_cache.py
@@ -1,0 +1,212 @@
+"""
+Unit tests for the in-process node cache in Neo4jStore (issue #66).
+
+These tests do NOT require a running Neo4j instance — they mock the driver/session.
+
+The strategy is:
+  - Build a store backed by MagicMock driver/session, bypassing open().
+  - Drive triples through add() + commit() and count session.run() calls.
+  - A cached node is skipped → one fewer session.run call for that URI's label group.
+  - Relationships always increment their own session.run calls.
+"""
+from unittest.mock import MagicMock
+from rdflib import URIRef, Literal
+from rdflib.namespace import FOAF
+
+from rdflib_neo4j.Neo4jStore import Neo4jStore
+from rdflib_neo4j.config.Neo4jStoreConfig import Neo4jStoreConfig
+from rdflib_neo4j.config.const import HANDLE_VOCAB_URI_STRATEGY
+
+
+def _make_store(node_cache_size=10000):
+    """
+    Build a Neo4jStore backed by a mock driver/session without a real Neo4j
+    instance. We bypass open() so no SHOW CONSTRAINTS roundtrip is needed.
+    """
+    mock_driver = MagicMock()
+    mock_session = MagicMock()
+    mock_driver.session.return_value = mock_session
+
+    config = Neo4jStoreConfig(
+        custom_prefixes={},
+        custom_mappings=[],
+        multival_props_names=[],
+        handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,
+        batching=True,
+        batch_size=5000,
+        node_cache_size=node_cache_size,
+    )
+    store = Neo4jStore(config=config, neo4j_driver=mock_driver)
+    # Bypass open() (constraint check) by setting internal state directly
+    store._Neo4jStore__open = True
+    store.session = mock_session
+    return store
+
+
+def _flush(store, *extras):
+    """
+    Flush all pending buffers.
+
+    We commit nodes (writes node_buffer to session.run) and rels separately.
+    After each commit the buffers are cleared, ready for the next pass.
+    """
+    store.commit(commit_nodes=True)
+    store.commit(commit_rels=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 1 – duplicate URI → only ONE node MERGE written to the session
+# ---------------------------------------------------------------------------
+
+def test_cached_node_skips_node_buffer():
+    """A node URI written a second time must NOT trigger another MERGE call."""
+    store = _make_store()
+    mock_session = store.session
+
+    donna = URIRef("https://example.org/donna")
+    other = URIRef("https://example.org/other1")
+
+    # --- First occurrence of donna ---
+    # Switch subjects to force donna into the buffer, then commit.
+    store.add((donna, FOAF.name, Literal("Donna")))
+    store.add((other, FOAF.name, Literal("Other")))   # flushes donna → buffer
+    _flush(store)
+
+    calls_after_first = mock_session.run.call_count  # includes node MERGE for donna
+
+    # --- Second occurrence of donna (should be cached / skipped) ---
+    other2 = URIRef("https://example.org/other2")
+    store.add((donna, FOAF.age, Literal(30)))
+    store.add((other2, FOAF.name, Literal("Other2")))  # flushes donna → skipped by cache
+    _flush(store)
+
+    calls_after_second = mock_session.run.call_count
+
+    # Only other2's node MERGE should have been emitted (1 new call).
+    # If donna was NOT cached, there would be 2 new calls (donna + other2).
+    new_calls = calls_after_second - calls_after_first
+    assert new_calls == 1, (
+        f"Expected exactly 1 new session.run call (other2 only), "
+        f"got {new_calls} — cache did not suppress donna's second MERGE"
+    )
+
+    # Verify donna is in the cache
+    assert donna in store._node_cache
+
+
+# ---------------------------------------------------------------------------
+# Test 2 – relationships are NOT skipped for cached nodes
+# ---------------------------------------------------------------------------
+
+def test_relationships_not_skipped_for_cached_nodes():
+    """Even if a node is cached, its outgoing relationships must still be written."""
+    store = _make_store()
+    mock_session = store.session
+
+    donna = URIRef("https://example.org/donna")
+    bob = URIRef("https://example.org/bob")
+    carol = URIRef("https://example.org/carol")
+    other = URIRef("https://example.org/flush-helper")
+
+    # First: donna→bob relationship
+    store.add((donna, FOAF.knows, bob))
+    store.add((other, FOAF.name, Literal("Other")))   # flush donna
+    _flush(store)
+
+    calls_after_first_rel = mock_session.run.call_count
+
+    # Second: donna→carol relationship; donna is now cached so node MERGE skipped,
+    # but the relationship MERGE must still be written.
+    store.add((donna, FOAF.knows, carol))
+    store.add((other, FOAF.age, Literal(1)))           # flush donna
+    _flush(store)
+
+    calls_after_second_rel = mock_session.run.call_count
+
+    # At least one more session.run call must have happened (for the new rel).
+    assert calls_after_second_rel > calls_after_first_rel, (
+        "No session.run calls detected for the second relationship — "
+        "relationships must not be suppressed by the node cache"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 – cache eviction when node_cache_size is exceeded
+# ---------------------------------------------------------------------------
+
+def test_cache_eviction():
+    """With cache size=2, adding a 3rd distinct URI must evict the oldest."""
+    store = _make_store(node_cache_size=2)
+
+    a = URIRef("https://example.org/a")
+    b = URIRef("https://example.org/b")
+    c = URIRef("https://example.org/c")
+    flush = URIRef("https://example.org/flush")
+
+    # Add a: switch to b to flush a → a cached
+    store.add((a, FOAF.name, Literal("A")))
+    store.add((b, FOAF.name, Literal("B")))   # flushes a → cache: {a}
+    # Add b: switch to c to flush b → b cached; cache: {a, b}
+    store.add((c, FOAF.name, Literal("C")))   # flushes b → cache: {a, b}
+    # Add c: switch to flush helper → c cached; cache overflows to 3 → a evicted
+    store.add((flush, FOAF.name, Literal("Flush")))  # flushes c → cache: {b, c}
+
+    # a should have been evicted (it was the oldest); b and c remain
+    assert a not in store._node_cache, "Oldest URI 'a' should have been evicted"
+    assert b in store._node_cache
+    assert c in store._node_cache
+    assert len(store._node_cache) == 2
+
+
+# ---------------------------------------------------------------------------
+# Test 4 – node_cache_size=0 disables caching entirely
+# ---------------------------------------------------------------------------
+
+def test_cache_size_zero_disables_cache():
+    """With node_cache_size=0, no URIs should ever be stored in the cache.
+
+    Both nodes (donna + other2) must appear in the UNWIND batch on the second
+    pass, proving that donna was NOT suppressed by a cache hit.
+    Nodes with the same labels are batched into one UNWIND query, so we check
+    the params list length rather than the session.run call count.
+    """
+    store = _make_store(node_cache_size=0)
+    mock_session = store.session
+
+    donna = URIRef("https://example.org/donna")
+    other1 = URIRef("https://example.org/other1")
+    other2 = URIRef("https://example.org/other2")
+
+    # First occurrence of donna
+    store.add((donna, FOAF.name, Literal("Donna")))
+    store.add((other1, FOAF.name, Literal("Other")))   # flush donna
+    _flush(store)
+
+    calls_after_first = mock_session.run.call_count
+
+    # Second occurrence of donna — with cache disabled, donna should flow through again
+    store.add((donna, FOAF.age, Literal(30)))
+    store.add((other2, FOAF.name, Literal("Other2")))  # flush donna
+    _flush(store)
+
+    # Inspect the params list of the UNWIND call(s) that appeared in the second pass.
+    # Nodes with the same labels are batched into one UNWIND query; donna and other2
+    # both have only the Resource label, so they share one call.
+    second_pass_calls = mock_session.run.call_args_list[calls_after_first:]
+    node_uris_written = []
+    for call in second_pass_calls:
+        if "params" in call.kwargs:
+            node_uris_written.extend(p["uri"] for p in call.kwargs["params"])
+
+    assert donna in node_uris_written, (
+        "donna must appear in the second-pass UNWIND params — "
+        "cache is disabled (node_cache_size=0) so it must not be suppressed"
+    )
+    assert other2 in node_uris_written, (
+        "other2 must appear in the second-pass UNWIND params"
+    )
+
+    # The internal cache dict must remain empty when size=0
+    assert len(store._node_cache) == 0, (
+        "Cache must remain empty when node_cache_size=0"
+    )

--- a/test/unit/test_remove.py
+++ b/test/unit/test_remove.py
@@ -1,0 +1,262 @@
+"""
+Unit tests for Neo4jStore.remove() and DeleteQueryComposer.
+
+These tests use mocks and do not require a running Neo4j instance.
+"""
+from unittest.mock import MagicMock
+from rdflib import URIRef, Literal, RDF
+from rdflib.term import BNode
+
+from rdflib_neo4j.Neo4jStore import Neo4jStore
+from rdflib_neo4j.config.Neo4jStoreConfig import Neo4jStoreConfig
+from rdflib_neo4j.config.const import HANDLE_VOCAB_URI_STRATEGY
+from rdflib_neo4j.query_composers.DeleteQueryComposer import DeleteQueryComposer
+
+EX = "http://example.org/"
+
+SUBJECT = URIRef(f"{EX}subject")
+OBJ_URI = URIRef(f"{EX}object")
+PRED_NAME = URIRef(f"{EX}name")
+PRED_KNOWS = URIRef(f"{EX}knows")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_store():
+    """Return an open Neo4jStore backed by a MagicMock session.
+
+    The store is constructed with a driver only (no auth_data), because the
+    Neo4jStore constructor rejects both being supplied simultaneously.
+    """
+    config = Neo4jStoreConfig(
+        # No auth_data — we supply a driver below
+        handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,
+    )
+    store = Neo4jStore(config=config, neo4j_driver=MagicMock())
+    store.session = MagicMock()
+    store.session.run.return_value = iter([])
+    # Bypass the open flag directly (avoid needing a live DB for constraint check)
+    store._Neo4jStore__open = True
+    return store
+
+
+# ---------------------------------------------------------------------------
+# DeleteQueryComposer unit tests
+# ---------------------------------------------------------------------------
+
+class TestDeleteQueryComposer:
+
+    def test_remove_property_query(self):
+        query, params = DeleteQueryComposer.remove_property("http://ex/a", "name")
+        assert "MATCH (n:Resource {uri: $uri})" in query
+        assert "REMOVE n.`name`" in query
+        assert params == {"uri": "http://ex/a"}
+
+    def test_remove_label_query(self):
+        query, params = DeleteQueryComposer.remove_label("http://ex/a", "Person")
+        assert "MATCH (n:Resource {uri: $uri})" in query
+        assert "REMOVE n:`Person`" in query
+        assert params == {"uri": "http://ex/a"}
+
+    def test_remove_relationship_query(self):
+        query, params = DeleteQueryComposer.remove_relationship(
+            "http://ex/a", "knows", "http://ex/b"
+        )
+        assert "MATCH (a:Resource {uri: $from_uri})" in query
+        assert "-[r:`knows`]->" in query
+        assert "(b:Resource {uri: $to_uri})" in query
+        assert "DELETE r" in query
+        assert params == {"from_uri": "http://ex/a", "to_uri": "http://ex/b"}
+
+    def test_remove_all_properties_query(self):
+        query, params = DeleteQueryComposer.remove_all_properties("http://ex/a")
+        assert "MATCH (n:Resource {uri: $uri})" in query
+        assert "SET n = {uri: n.uri}" in query
+        assert params == {"uri": "http://ex/a"}
+
+    def test_remove_all_relationships_query(self):
+        query, params = DeleteQueryComposer.remove_all_relationships("http://ex/a")
+        assert "MATCH (n:Resource {uri: $uri})-[r]->()" in query
+        assert "DELETE r" in query
+        assert params == {"uri": "http://ex/a"}
+
+    def test_remove_all_outgoing_of_type_query(self):
+        query, params = DeleteQueryComposer.remove_all_outgoing_of_type("http://ex/a", "knows")
+        assert "-[r:`knows`]->()" in query
+        assert "DELETE r" in query
+        assert params == {"uri": "http://ex/a"}
+
+    def test_remove_node_if_empty_query(self):
+        query, params = DeleteQueryComposer.remove_node_if_empty("http://ex/a")
+        assert "size(keys(n)) <= 1" in query
+        assert "DELETE n" in query
+        assert params == {"uri": "http://ex/a"}
+
+
+# ---------------------------------------------------------------------------
+# Neo4jStore.remove() tests — literal (property) retraction
+# ---------------------------------------------------------------------------
+
+class TestRemoveLiteral:
+
+    def test_remove_literal_triple_calls_session_run(self):
+        store = make_store()
+        triple = (SUBJECT, PRED_NAME, Literal("Alice"))
+        store.remove(triple)
+        store.session.run.assert_called_once()
+        call_args = store.session.run.call_args
+        query = call_args[0][0]
+        assert "REMOVE n.`name`" in query
+        params = call_args[1]["params"]
+        assert params["uri"] == str(SUBJECT)
+
+    def test_remove_literal_uses_ignore_strategy(self):
+        """With IGNORE strategy the property name is the local part of the predicate."""
+        store = make_store()
+        triple = (SUBJECT, URIRef(f"{EX}fullName"), Literal("Bob"))
+        store.remove(triple)
+        query = store.session.run.call_args[0][0]
+        assert "REMOVE n.`fullName`" in query
+
+    def test_remove_literal_with_none_subject_logs_warning(self, caplog):
+        import logging
+        store = make_store()
+        triple = (None, PRED_NAME, Literal("Alice"))
+        with caplog.at_level(logging.WARNING):
+            store.remove(triple)
+        store.session.run.assert_not_called()
+        assert "wildcard" in caplog.text.lower() or "not yet supported" in caplog.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Neo4jStore.remove() tests — rdf:type (label) retraction
+# ---------------------------------------------------------------------------
+
+class TestRemoveLabel:
+
+    def test_remove_rdf_type_triple_removes_label(self):
+        store = make_store()
+        triple = (SUBJECT, RDF.type, URIRef(f"{EX}Person"))
+        store.remove(triple)
+        store.session.run.assert_called_once()
+        query = store.session.run.call_args[0][0]
+        assert "REMOVE n:`Person`" in query
+
+    def test_remove_rdf_type_with_none_object_keeps_resource_label(self):
+        store = make_store()
+        triple = (SUBJECT, RDF.type, None)
+        store.remove(triple)
+        store.session.run.assert_called_once()
+        query = store.session.run.call_args[0][0]
+        assert "SET n:Resource" in query
+
+    def test_remove_rdf_type_with_none_subject_returns_early(self):
+        store = make_store()
+        triple = (None, RDF.type, URIRef(f"{EX}Person"))
+        store.remove(triple)
+        store.session.run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Neo4jStore.remove() tests — URI object (relationship) retraction
+# ---------------------------------------------------------------------------
+
+class TestRemoveRelationship:
+
+    def test_remove_uri_object_triple_deletes_relationship(self):
+        store = make_store()
+        triple = (SUBJECT, PRED_KNOWS, OBJ_URI)
+        store.remove(triple)
+        store.session.run.assert_called_once()
+        query = store.session.run.call_args[0][0]
+        assert "DELETE r" in query
+        assert "-[r:`knows`]->" in query
+
+    def test_remove_uri_object_params_contain_both_uris(self):
+        store = make_store()
+        triple = (SUBJECT, PRED_KNOWS, OBJ_URI)
+        store.remove(triple)
+        params = store.session.run.call_args[1]["params"]
+        assert params["from_uri"] == str(SUBJECT)
+        assert params["to_uri"] == str(OBJ_URI)
+
+    def test_remove_uri_with_none_predicate_deletes_any_rel_to_object(self):
+        store = make_store()
+        triple = (SUBJECT, None, OBJ_URI)
+        store.remove(triple)
+        store.session.run.assert_called_once()
+        query = store.session.run.call_args[0][0]
+        # No specific rel type — should delete any relationship between the two nodes
+        assert "DELETE r" in query
+        assert "$from_uri" in query
+        assert "$to_uri" in query
+
+    def test_remove_uri_with_none_subject_returns_early(self):
+        store = make_store()
+        triple = (None, PRED_KNOWS, OBJ_URI)
+        store.remove(triple)
+        store.session.run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# BNode normalisation
+# ---------------------------------------------------------------------------
+
+class TestBNodeNormalisation:
+
+    def test_bnode_subject_normalised_to_bnode_uri(self):
+        store = make_store()
+        bnode = BNode("abc123")
+        triple = (bnode, PRED_NAME, Literal("Alice"))
+        store.remove(triple)
+        store.session.run.assert_called_once()
+        params = store.session.run.call_args[1]["params"]
+        assert params["uri"] == "bnode://abc123"
+
+    def test_bnode_object_normalised_to_bnode_uri(self):
+        store = make_store()
+        bnode = BNode("xyz789")
+        triple = (SUBJECT, PRED_KNOWS, bnode)
+        store.remove(triple)
+        store.session.run.assert_called_once()
+        params = store.session.run.call_args[1]["params"]
+        assert params["to_uri"] == "bnode://xyz789"
+
+
+# ---------------------------------------------------------------------------
+# Node cache eviction
+# ---------------------------------------------------------------------------
+
+class TestNodeCacheEviction:
+
+    def test_cache_evicted_when_subject_removed(self):
+        store = make_store()
+        subject_uri_str = str(SUBJECT)
+        # Pre-populate the cache
+        store._node_cache[subject_uri_str] = True
+
+        triple = (SUBJECT, PRED_NAME, Literal("Alice"))
+        store.remove(triple)
+
+        assert subject_uri_str not in store._node_cache
+
+    def test_cache_not_touched_for_uncached_subject(self):
+        store = make_store()
+        # Cache is empty — removal of an uncached subject should not raise
+        triple = (SUBJECT, PRED_NAME, Literal("Alice"))
+        store.remove(triple)  # should not raise KeyError
+
+    def test_other_cache_entries_untouched(self):
+        store = make_store()
+        other_uri = str(URIRef(f"{EX}other"))
+        store._node_cache[other_uri] = True
+        store._node_cache[str(SUBJECT)] = True
+
+        triple = (SUBJECT, PRED_NAME, Literal("Alice"))
+        store.remove(triple)
+
+        # Only the subject entry is evicted
+        assert other_uri in store._node_cache
+        assert str(SUBJECT) not in store._node_cache


### PR DESCRIPTION
## Summary
- New `rdflib_neo4j/query_composers/DeleteQueryComposer.py` with static Cypher generators for all retraction cases
- `Neo4jStore.remove()` now fully implemented (was `raise NotImplemented`)
- Dispatches on triple object type:
  - `Literal` → `REMOVE n.<prop>` (property retraction)
  - `rdf:type` predicate → `REMOVE n:<label>` (label retraction)
  - URI/BNode object → `DELETE r` (relationship deletion)
- BNode subjects/objects normalised to `bnode://` URIs
- Node cache evicted when subject is removed
- Wildcard `None` components handled for common cases

## Test plan
- [ ] 26 unit tests in `test/unit/test_remove.py` — all passing
- [ ] `DeleteQueryComposer` Cypher output verified for all 7 static methods
- [ ] All three dispatch cases (literal, rdf:type, URI) exercised
- [ ] BNode normalisation and cache eviction tested

Closes #54