### PR TITLE
chore: enhance CI with lint, compile check, and write-access gate

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,17 +1,22 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# Runs compile check, linter, and tests on PRs from members with write access.
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Integration tests
+name: CI
 
 on:
   push:
     branches: ["develop"]
   pull_request:
-    branches: [ "master","develop" ]
+    branches: ["master", "develop"]
 
 jobs:
-  build:
+  ci:
     runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'push' ||
+      github.event.pull_request.author_association == 'OWNER' ||
+      github.event.pull_request.author_association == 'MEMBER' ||
+      github.event.pull_request.author_association == 'COLLABORATOR'
     strategy:
       fail-fast: true
       matrix:
@@ -28,6 +33,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install ruff
+    - name: Compile check
+      run: python -m compileall rdflib_neo4j/
+    - name: Lint
+      run: ruff check rdflib_neo4j/ test/unit/
     - name: Test with pytest
       run: |
         pytest


### PR DESCRIPTION
## Summary

- Adds `ruff` lint check (`rdflib_neo4j/` + `test/unit/`) and `compileall` compile check as steps before pytest
- Gates PR runs on `author_association` — only `OWNER`, `MEMBER`, and `COLLABORATOR` trigger CI; external contributors are skipped
- Push events on `develop` always run (gate is PR-only)
- Renames job `build` → `ci` and workflow `Integration tests` → `CI`

## Test plan

- [ ] Open a PR from a fork — CI should not trigger
- [ ] Open a PR from a project branch — CI should run all three steps
- [ ] Introduce a lint error — `Lint` step should fail before pytest runs