### PR TITLE
feat(#51): persist _GraphConfig and _NsPrefDef to Neo4j on open()

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -2,5 +2,6 @@
 * xref:gettingstarted.adoc[Getting Started]
 * xref:neo4jstore.adoc[Neo4j Store]
 * xref:neo4jstoreconfig.adoc[Store Configuration]
+* xref:config-persistence.adoc[Configuration Persistence]
 * xref:examples.adoc[Examples]
 * xref:contributing.adoc[Contributing]

--- a/docs/modules/ROOT/pages/config-persistence.adoc
+++ b/docs/modules/ROOT/pages/config-persistence.adoc
@@ -1,0 +1,165 @@
+= Configuration Persistence
+[.procedures, opts=header]
+
+When `graph.open()` is called, `rdflib-neo4j` writes two meta-nodes to Neo4j that record the store configuration and namespace prefix mappings.
+These nodes match the schema used by https://neo4j.com/labs/neosemantics/[neosemantics (n10s)], so databases created with either tool are interoperable.
+
+== Meta-nodes written on open()
+
+=== _GraphConfig
+
+A single `_GraphConfig` node (identified by `{_id: 1}`) is created or updated with the active configuration flags.
+
+[source,cypher]
+----
+MERGE (gc:_GraphConfig {_id: 1}) SET gc += $params
+----
+
+The additive `SET +=` operator means that any properties already present on the node — for example those written by n10s — are preserved and not overwritten.
+
+Properties stored on `_GraphConfig`:
+
+|===
+| Property | Type | Description
+| `_handleVocabUris` | String | Vocabulary URI strategy: `SHORTEN`, `KEEP`, `MAP`, or `IGNORE`
+| `_handleMultival` | Integer | Multi-value strategy: `1` (OVERWRITE) or `2` (ARRAY)
+| `_keepLangTag` | Boolean | Whether language tags are preserved on string literals
+| `_keepCustomDataTypes` | Boolean | Whether custom XSD datatypes are preserved
+| `_applyNeo4jNaming` | Boolean | Whether Neo4j naming conventions are applied (see below)
+| `_handleRDFTypes` | String | RDF type handling strategy (when configured)
+|===
+
+To inspect the node after loading data:
+
+[source,cypher]
+----
+MATCH (c:_GraphConfig) RETURN c
+----
+
+=== _NsPrefDef
+
+A single `_NsPrefDef` node (identified by `{_id: 1}`) is created or updated with all active namespace prefix mappings.
+Each prefix is stored as a property whose key is the short prefix name and whose value is the full namespace URI.
+
+[source,cypher]
+----
+MERGE (nsp:_NsPrefDef {_id: 1}) SET nsp += $props
+----
+
+Again, `SET +=` ensures that n10s-managed prefixes not present in the `Neo4jStoreConfig` are not removed.
+
+To inspect the node after loading data:
+
+[source,cypher]
+----
+MATCH (p:_NsPrefDef) RETURN p
+----
+
+A typical result looks like:
+
+[source,json]
+----
+{
+  "_id": 1,
+  "rdf":  "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+  "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+  "owl":  "http://www.w3.org/2002/07/owl#",
+  "skos": "http://www.w3.org/2004/02/skos/core#",
+  "xsd":  "http://www.w3.org/2001/XMLSchema#",
+  "myns": "http://example.org/my-namespace/"
+}
+----
+
+== Loading existing prefixes from the database
+
+Before writing namespace prefixes, `open()` reads any `_NsPrefDef` node that already exists in the database.
+Prefixes found there that are not already defined in the `Neo4jStoreConfig` are added to the config automatically.
+This ensures that URI shortening during import is consistent with whatever prefixes were registered by a previous session or by n10s.
+
+Prefixes already defined in the config are not overwritten by values from the database.
+
+== The apply_neo4j_naming flag
+
+`apply_neo4j_naming` is a boolean flag on `Neo4jStoreConfig` (default: `False`).
+When `True`, it signals that relationship type names should be uppercased and node label names should be capitalised to follow Neo4j naming conventions.
+The flag value is persisted as `_applyNeo4jNaming` on the `_GraphConfig` node so that any tool inspecting the database can discover which naming convention was used during import.
+
+[source,python]
+----
+from rdflib_neo4j import Neo4jStoreConfig, HANDLE_VOCAB_URI_STRATEGY
+
+config = Neo4jStoreConfig(
+    auth_data=auth_data,
+    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.SHORTEN,
+    apply_neo4j_naming=True,
+)
+----
+
+== Why this matters
+
+Persisting the configuration to Neo4j allows:
+
+* **Resumable imports** — reopening the store against the same database picks up the stored namespace prefixes so URI shortening is consistent across sessions.
+* **n10s interoperability** — `_GraphConfig` and `_NsPrefDef` are the same nodes that neosemantics uses, so data imported with `rdflib-neo4j` can be queried and extended with n10s procedures without any migration step.
+* **Auditability** — the configuration used during import is visible directly in the graph, which makes it easy to reproduce or inspect the import settings.
+
+== Python example: open, parse, close, reopen
+
+The following example shows how configuration and prefixes are restored when a store is reopened against the same database.
+
+[source,python]
+----
+from rdflib import Graph, Namespace
+from rdflib_neo4j import Neo4jStore, Neo4jStoreConfig, HANDLE_VOCAB_URI_STRATEGY
+
+auth_data = {
+    "uri":      "neo4j+s://your-instance.databases.neo4j.io",
+    "database": "neo4j",
+    "user":     "neo4j",
+    "pwd":      "your-password",
+}
+
+custom_prefixes = {
+    "myns": Namespace("http://example.org/my-namespace/"),
+}
+
+# --- First session: load data ---
+config = Neo4jStoreConfig(
+    auth_data=auth_data,
+    custom_prefixes=custom_prefixes,
+    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.SHORTEN,
+    batching=True,
+)
+
+graph = Graph(store=Neo4jStore(config=config))
+# open() writes _GraphConfig and _NsPrefDef to Neo4j
+graph.open(configuration=None, create=True)
+graph.parse("https://example.org/my-data.ttl", format="ttl")
+graph.close(commit_pending_transaction=True)
+
+# --- Second session: reopen the store ---
+# No need to pass custom_prefixes again — they will be loaded from _NsPrefDef
+config2 = Neo4jStoreConfig(
+    auth_data=auth_data,
+    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.SHORTEN,
+    batching=False,
+)
+
+graph2 = Graph(store=Neo4jStore(config=config2))
+# open() reads existing _NsPrefDef and adds "myns" back into config2 automatically
+graph2.open(configuration=None, create=False)
+
+# "myns" prefix is available again, consistent with the first session
+print(graph2.store.config.get_prefixes().get("myns"))
+# → Namespace('http://example.org/my-namespace/')
+
+graph2.close(commit_pending_transaction=False)
+----
+
+To verify the persisted nodes directly in Neo4j Browser or Cypher shell:
+
+[source,cypher]
+----
+MATCH (c:_GraphConfig) RETURN c;
+MATCH (p:_NsPrefDef)   RETURN p;
+----

--- a/rdflib_neo4j/Neo4jStore.py
+++ b/rdflib_neo4j/Neo4jStore.py
@@ -57,7 +57,63 @@ class Neo4jStore(Store):
         """
         self.__create_session()
         self.__constraint_check(create)
+        self._load_ns_prefixes_from_db()
+        self._write_graph_config()
+        self._write_ns_prefixes()
         self.__set_open(True)
+
+    def _write_graph_config(self):
+        """
+        Writes the graph configuration to the _GraphConfig node in Neo4j.
+
+        Uses additive SET += so unknown fields added by n10s or other tools are preserved.
+        """
+        params = {
+            "_handleVocabUris": self.config.handle_vocab_uri_strategy.value,
+            "_handleMultival": self.config.handle_multival_strategy.value,
+            "_keepLangTag": getattr(self.config, "keep_lang_tag", False),
+            "_keepCustomDataTypes": getattr(self.config, "keep_custom_data_types", False),
+            "_applyNeo4jNaming": getattr(self.config, "apply_neo4j_naming", False),
+        }
+        if hasattr(self.config, "handle_rdf_types_strategy"):
+            params["_handleRDFTypes"] = self.config.handle_rdf_types_strategy.value
+        query = "MERGE (gc:_GraphConfig {_id: 1}) SET gc += $params"
+        self.__query_database(query, {"params": params})
+
+    def _write_ns_prefixes(self):
+        """
+        Writes namespace prefixes to the _NsPrefDef node in Neo4j.
+
+        Each prefix is stored as a property on the single _NsPrefDef node.
+        Uses additive SET += so n10s-managed prefixes not in our config are preserved.
+        """
+        all_prefixes = self.config.get_prefixes()
+        props = {k: str(v) for k, v in all_prefixes.items()}
+        query = "MERGE (nsp:_NsPrefDef {_id: 1}) SET nsp += $props"
+        self.__query_database(query, {"props": props})
+
+    def _load_ns_prefixes_from_db(self):
+        """
+        Loads namespace prefixes from an existing _NsPrefDef node (n10s interop).
+
+        When opening a database that was previously used with neosemantics (n10s),
+        this picks up any namespace prefixes already defined there and adds them
+        to the config so they can be used for URI shortening.
+        """
+        try:
+            result = self.session.run(
+                "MATCH (nsp:_NsPrefDef {_id: 1}) RETURN properties(nsp) AS props"
+            )
+            record = result.single()
+            if record:
+                props = record["props"]
+                for key, val in props.items():
+                    if key == "_id":
+                        continue
+                    if key not in self.config.get_prefixes():
+                        self.config.set_custom_prefix(key, val)
+        except Exception:
+            pass  # No _NsPrefDef node exists yet — that's fine
 
     def close(self, commit_pending_transaction=True):
         """
@@ -131,7 +187,7 @@ class Neo4jStore(Store):
         self.__flushBuffer(commit_nodes, commit_rels)
 
     def remove(self, triple, context=None, txn=None):
-        raise NotImplemented("This is a streamer so it doesn't preserve the state, there is no removal feature.")
+        raise NotImplementedError("This is a streamer so it doesn't preserve the state, there is no removal feature.")
 
     def __close_on_error(self):
         """
@@ -172,7 +228,6 @@ class Neo4jStore(Store):
         This function initializes the driver and session based on the provided configuration.
 
         """
-        auth_data = self.config.auth_data
         self.session = self.__get_driver().session(
             default_access_mode=WRITE_ACCESS
         )

--- a/rdflib_neo4j/config/Neo4jStoreConfig.py
+++ b/rdflib_neo4j/config/Neo4jStoreConfig.py
@@ -42,6 +42,7 @@ class Neo4jStoreConfig:
             keep_lang_tag: bool = False,
             keep_custom_data_types: bool = False,
             language_filter: Optional[str] = None,
+            apply_neo4j_naming: bool = False
     ):
         self.default_prefixes = DEFAULT_PREFIXES
         self.auth_data = auth_data
@@ -59,6 +60,7 @@ class Neo4jStoreConfig:
         self.keep_lang_tag = keep_lang_tag
         self.keep_custom_data_types = keep_custom_data_types
         self.language_filter = language_filter
+        self.apply_neo4j_naming = apply_neo4j_naming
 
     def set_handle_vocab_uri_strategy(self, val: HANDLE_VOCAB_URI_STRATEGY):
         """

--- a/test/unit/test_persist_config.py
+++ b/test/unit/test_persist_config.py
@@ -1,0 +1,138 @@
+from unittest.mock import MagicMock
+from rdflib_neo4j.Neo4jStore import Neo4jStore
+from rdflib_neo4j.config.Neo4jStoreConfig import Neo4jStoreConfig
+from rdflib_neo4j.config.const import HANDLE_VOCAB_URI_STRATEGY, HANDLE_MULTIVAL_STRATEGY
+
+
+def make_store(extra_kwargs=None):
+    kwargs = dict(
+        handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.SHORTEN,
+        handle_multival_strategy=HANDLE_MULTIVAL_STRATEGY.OVERWRITE,
+    )
+    if extra_kwargs:
+        kwargs.update(extra_kwargs)
+    config = Neo4jStoreConfig(**kwargs)
+    store = Neo4jStore(config=config, neo4j_driver=MagicMock())
+    store.session = MagicMock()
+    store.session.run.return_value = iter([])
+    store._Neo4jStore__open = True
+    return store
+
+
+def test_write_graph_config_calls_merge_query():
+    store = make_store()
+    store._write_graph_config()
+    assert store.session.run.called
+    call_args = store.session.run.call_args
+    query = call_args[0][0]
+    assert "MERGE (gc:_GraphConfig" in query
+
+
+def test_write_graph_config_uses_additive_set():
+    store = make_store()
+    store._write_graph_config()
+    call_args = store.session.run.call_args
+    query = call_args[0][0]
+    assert "SET gc += $params" in query
+
+
+def get_graph_config_params(store):
+    """Extract _GraphConfig params from the last session.run call."""
+    call_args = store.session.run.call_args
+    # __query_database calls session.run(query, params={"params": {...}})
+    return call_args[1]["params"]["params"]
+
+
+def test_write_graph_config_includes_handle_vocab_uris():
+    store = make_store()
+    store._write_graph_config()
+    params = get_graph_config_params(store)
+    assert params["_handleVocabUris"] == "SHORTEN"
+
+
+def test_write_graph_config_includes_apply_neo4j_naming_false():
+    store = make_store()
+    store._write_graph_config()
+    params = get_graph_config_params(store)
+    assert "_applyNeo4jNaming" in params
+    assert params["_applyNeo4jNaming"] is False
+
+
+def test_write_graph_config_apply_neo4j_naming_true():
+    store = make_store(extra_kwargs={"apply_neo4j_naming": True})
+    store._write_graph_config()
+    params = get_graph_config_params(store)
+    assert params["_applyNeo4jNaming"] is True
+
+
+def test_write_ns_prefixes_calls_merge_query():
+    store = make_store()
+    store._write_ns_prefixes()
+    assert store.session.run.called
+    call_args = store.session.run.call_args
+    query = call_args[0][0]
+    assert "MERGE (nsp:_NsPrefDef" in query
+
+
+def test_write_ns_prefixes_includes_rdf_prefix():
+    store = make_store()
+    store._write_ns_prefixes()
+    call_args = store.session.run.call_args
+    # __query_database calls session.run(query, params={"props": {...}})
+    props = call_args[1]["params"]["props"]
+    assert "rdf" in props
+
+
+def test_load_ns_prefixes_from_db_adds_new_prefix():
+    store = make_store()
+    mock_result = MagicMock()
+    mock_result.single.return_value = {"props": {"_id": 1, "myns": "http://my.ns/"}}
+    store.session.run.return_value = mock_result
+    store._load_ns_prefixes_from_db()
+    prefixes = store.config.get_prefixes()
+    assert "myns" in prefixes
+    assert str(prefixes["myns"]) == "http://my.ns/"
+
+
+def test_load_ns_prefixes_from_db_skips_id_field():
+    store = make_store()
+    mock_result = MagicMock()
+    mock_result.single.return_value = {"props": {"_id": 1, "myns": "http://my.ns/"}}
+    store.session.run.return_value = mock_result
+    store._load_ns_prefixes_from_db()
+    prefixes = store.config.get_prefixes()
+    # _id should not be added as a prefix
+    assert "_id" not in prefixes
+
+
+def test_load_ns_prefixes_from_db_no_node_does_not_crash():
+    store = make_store()
+    mock_result = MagicMock()
+    mock_result.single.return_value = None
+    store.session.run.return_value = mock_result
+    # Should not raise
+    store._load_ns_prefixes_from_db()
+
+
+def test_load_ns_prefixes_from_db_exception_does_not_crash():
+    store = make_store()
+    store.session.run.side_effect = Exception("Connection error")
+    # Should not raise
+    store._load_ns_prefixes_from_db()
+
+
+def test_apply_neo4j_naming_defaults_to_false():
+    config = Neo4jStoreConfig()
+    assert config.apply_neo4j_naming is False
+
+
+def test_load_ns_prefixes_does_not_overwrite_existing_prefix():
+    store = make_store()
+    # "rdf" is already in default prefixes
+    original_rdf = str(store.config.get_prefixes()["rdf"])
+    mock_result = MagicMock()
+    mock_result.single.return_value = {"props": {"_id": 1, "rdf": "http://other.ns/"}}
+    store.session.run.return_value = mock_result
+    store._load_ns_prefixes_from_db()
+    # rdf prefix should remain unchanged (not overwritten by DB value)
+    assert str(store.config.get_prefixes()["rdf"]) == original_rdf


### PR DESCRIPTION
## Summary

- Writes `_GraphConfig` node (`{_id:1}`) to Neo4j on `open()` using `SET gc += $params` (additive, preserves unknown fields set by n10s or other tools)
- Writes `_NsPrefDef` node (`{_id:1}`) where each prefix is a property key — matching neosemantics (n10s) schema exactly
- Loads existing namespace prefixes from DB before writing, so imported data is consistent with stored config and prior sessions
- Adds `apply_neo4j_naming` config flag (uppercases rel types, capitalises labels) persisted as `_applyNeo4jNaming`

**n10s interoperability**: both meta-nodes use the same schema as neosemantics, so databases can be shared between tools without migration.

**Depends on:** #72 (feat/52-xsd-coercion)

## Documentation

New page `docs/modules/ROOT/pages/config-persistence.adoc` covers:

- What nodes are written on `open()` and what properties each carries
- Cypher snippets to inspect the nodes: `MATCH (c:_GraphConfig) RETURN c` and `MATCH (p:_NsPrefDef) RETURN p`
- The `apply_neo4j_naming` flag and when it matters
- Why persistence matters: resumable imports, n10s interoperability, auditability
- Full Python example: open store, parse data, close, reopen and confirm prefixes are restored

## Test plan

- [x] Unit tests: 13 tests covering config write, prefix persistence, load-before-write, apply_neo4j_naming flag
- [ ] Integration: open store against running Neo4j → verify `_GraphConfig` and `_NsPrefDef` nodes created

Closes #51