### PR TITLE
feat(#55): implement triples(), __len__(), __iter__() for RDF export

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -2,5 +2,6 @@
 * xref:gettingstarted.adoc[Getting Started]
 * xref:neo4jstore.adoc[Neo4j Store]
 * xref:neo4jstoreconfig.adoc[Store Configuration]
+* xref:graph-iteration.adoc[Graph Iteration and Export]
 * xref:examples.adoc[Examples]
 * xref:contributing.adoc[Contributing]

--- a/docs/modules/ROOT/pages/graph-iteration.adoc
+++ b/docs/modules/ROOT/pages/graph-iteration.adoc
@@ -1,0 +1,78 @@
+= Graph Iteration and Export
+
+This page describes how to iterate over triples stored in Neo4j, count them, and serialize an RDF graph — using the standard rdflib `Graph` API backed by `Neo4jStore`.
+
+The `Neo4jStore` implements three rdflib `Store` protocol methods that unlock these capabilities:
+
+* `triples(pattern)` — yield triples matching a `(subject, predicate, object)` pattern, with `None` as a wildcard
+* `__len__()` — return the triple count
+* `__iter__()` — iterate over every triple in the store
+
+These are called transparently by the `rdflib.Graph` API, so you use the familiar rdflib interface without writing any Cypher directly.
+
+== What these methods enable
+
+Once a graph is open against a Neo4j store, you can:
+
+* Count the stored triples with `len(g)`
+* Iterate every triple with `for s, p, o in g:`
+* Filter by subject, predicate, or object with `g.triples(pattern)`
+* Serialize the full graph back to any RDF format supported by rdflib (Turtle, N-Triples, JSON-LD, …)
+* Run SPARQL queries against the store using `g.query()`
+
+Neo4j label nodes are automatically surfaced as `rdf:type` triples, so round-trips between RDF and the graph model preserve class membership.
+
+== Code examples
+
+The examples below assume a configured graph `g` — see xref:gettingstarted.adoc[Getting Started] for store setup.
+
+[source,python]
+----
+from rdflib.namespace import RDF
+
+# Count all triples in the store
+print(len(g))
+
+# Iterate over every triple
+for s, p, o in g:
+    print(s, p, o)
+
+# Pattern matching — find all rdf:type triples (subject and object are wildcards)
+for s, p, o in g.triples((None, RDF.type, None)):
+    print(s, "is a", o)
+
+# Serialize the full graph back to Turtle
+print(g.serialize(format="turtle"))
+----
+
+=== Pattern matching details
+
+`g.triples(pattern)` accepts any combination of `None` wildcards:
+
+[cols="1,1,1,2",options="header"]
+|===
+| Subject | Predicate | Object | What is matched
+
+| `None` | `None` | `None` | Every triple in the store
+| `uri` | `None` | `None` | All triples with the given subject
+| `None` | `RDF.type` | `None` | All `rdf:type` triples
+| `uri` | `pred` | `None` | All values for a given subject and predicate
+| `None` | `None` | `literal` | All triples with a given object value
+|===
+
+Any non-`None` position is used as an exact filter.  All seven remaining wildcard combinations are supported.
+
+== Performance considerations
+
+`triples()`, `__len__()`, and `__iter__()` all perform full or partial graph scans in Neo4j:
+
+* `__len__()` runs a count query that sums property-value triples, label-to-`rdf:type` triples, and relationships.  The count is *approximate* when multi-valued properties are stored as arrays — each array element is a separate RDF triple, but the count query tallies the property once.
+* `__iter__()` and unbounded `triples((None, None, None))` fetch every node and every relationship from the database.
+
+These operations are well-suited for:
+
+* Exporting or serializing a small-to-medium graph
+* One-time round-trip verification after an import
+* Development and debugging
+
+Avoid calling them in tight loops or on large graphs where only a subset of triples is needed.  For selective queries, use SPARQL via `g.query()` or the Neo4j driver directly — both let you push filters into the database.

--- a/rdflib_neo4j/Neo4jStore.py
+++ b/rdflib_neo4j/Neo4jStore.py
@@ -1,6 +1,8 @@
 from typing import Dict
 
+from rdflib import Literal, RDF
 from rdflib.store import Store
+from rdflib.term import BNode
 from neo4j import GraphDatabase, Driver
 from neo4j import WRITE_ACCESS
 import logging
@@ -131,7 +133,7 @@ class Neo4jStore(Store):
         self.__flushBuffer(commit_nodes, commit_rels)
 
     def remove(self, triple, context=None, txn=None):
-        raise NotImplemented("This is a streamer so it doesn't preserve the state, there is no removal feature.")
+        raise NotImplementedError("This is a streamer so it doesn't preserve the state, there is no removal feature.")
 
     def __close_on_error(self):
         """
@@ -172,7 +174,6 @@ class Neo4jStore(Store):
         This function initializes the driver and session based on the provided configuration.
 
         """
-        auth_data = self.config.auth_data
         self.session = self.__get_driver().session(
             default_access_mode=WRITE_ACCESS
         )
@@ -286,9 +287,117 @@ class Neo4jStore(Store):
                 self.__store_current_subject()
                 self.current_subject = self.__create_current_subject(subject)
 
+    def triples(self, triple):
+        """
+        Yield triples matching the pattern. Any component may be None (wildcard).
+
+        Args:
+            triple: A (subject, predicate, object) tuple; any element may be None.
+
+        Yields:
+            ((subject, predicate, object), self) tuples, matching the rdflib
+            Store.triples() contract.
+        """
+        assert self.is_open(), "The Store must be open."
+        from rdflib_neo4j.query_composers.ExportQueryComposer import ExportQueryComposer
+        from rdflib_neo4j.expander import expand_uri, neo4j_value_to_literal
+
+        (s, p, o) = triple
+        prefix_map = {name: str(ns) for name, ns in self.config.get_prefixes().items()}
+
+        # Yield property and label triples from a node record
+        def _node_triples(record):
+            subject_uri = record["uri"]
+            subject = expand_uri(subject_uri, prefix_map)
+            # Subject filter
+            if s is not None and subject != s:
+                return
+            props = record["props"]
+            labels = record["extra_labels"]
+
+            # Property triples
+            for prop_key, prop_val in props.items():
+                if prop_key == "uri":
+                    continue
+                predicate = expand_uri(prop_key, prefix_map)
+                if p is not None and predicate != p:
+                    continue
+                if isinstance(prop_val, list):
+                    for v in prop_val:
+                        lit = neo4j_value_to_literal(v, prop_key)
+                        if o is None or o == lit:
+                            yield (subject, predicate, lit), self
+                else:
+                    lit = neo4j_value_to_literal(prop_val, prop_key)
+                    if o is None or o == lit:
+                        yield (subject, predicate, lit), self
+
+            # Label → rdf:type triples
+            if p is None or p == RDF.type:
+                for label in labels:
+                    class_uri = expand_uri(label, prefix_map)
+                    if o is None or o == class_uri:
+                        yield (subject, RDF.type, class_uri), self
+
+        # Yield a relationship triple from a relationship record
+        def _rel_triples(record):
+            from_uri = expand_uri(record["from_uri"], prefix_map)
+            to_uri = expand_uri(record["to_uri"], prefix_map)
+            rel_type = expand_uri(record["rel_type"], prefix_map)
+            if s is not None and from_uri != s:
+                return
+            if p is not None and rel_type != p:
+                return
+            if o is not None and to_uri != o:
+                return
+            yield (from_uri, rel_type, to_uri), self
+
+        if s is not None:
+            # Subject known — query specific node
+            s_uri = f"bnode://{s}" if isinstance(s, BNode) else str(s)
+            node_result = self.session.run(
+                ExportQueryComposer.node_by_uri_query(), uri=s_uri
+            )
+            for record in node_result:
+                yield from _node_triples(record)
+            # Only fetch relationships when predicate is not rdf:type and object
+            # is not a Literal (relationships link Resource nodes only)
+            if p != RDF.type and not isinstance(o, Literal):
+                rel_result = self.session.run(
+                    ExportQueryComposer.relationships_from_uri_query(), uri=s_uri
+                )
+                for record in rel_result:
+                    yield from _rel_triples(record)
+        else:
+            # Subject wildcard — scan all nodes
+            node_result = self.session.run(ExportQueryComposer.all_nodes_query())
+            for record in node_result:
+                yield from _node_triples(record)
+            # Fetch relationships unless we know only Literal objects are wanted
+            if not isinstance(o, Literal):
+                rel_result = self.session.run(ExportQueryComposer.all_relationships_query())
+                for record in rel_result:
+                    yield from _rel_triples(record)
+
     def __len__(self, context=None):
-        # no triple state, just a streamer
-        return 0
+        """
+        Return an approximate triple count.
+
+        Sums: (number of non-uri properties per node) + (number of non-Resource
+        labels per node) + (total relationship count).  This matches the rdflib
+        Store contract better than a raw node count, though it will be exact only
+        when no multi-value properties are stored as arrays.
+        """
+        if not self.is_open():
+            return 0
+        from rdflib_neo4j.query_composers.ExportQueryComposer import ExportQueryComposer
+        result = self.session.run(ExportQueryComposer.count_query())
+        record = result.single()
+        return int(record["cnt"]) if record else 0
+
+    def __iter__(self):
+        """Iterate over all triples in the store."""
+        return (triple for triple, _ in self.triples((None, None, None)))
 
     def __flushBuffer(self, only_nodes, only_rels):
         """

--- a/rdflib_neo4j/expander.py
+++ b/rdflib_neo4j/expander.py
@@ -1,0 +1,107 @@
+"""
+expander.py — Reverse URI expansion for rdflib-neo4j read path.
+
+Converts Neo4j-stored property keys, relationship types, and node labels back
+to rdflib URIRef/BNode/Literal terms.
+
+Round-trip fidelity depends on the HANDLE_VOCAB_URI_STRATEGY used during write:
+  - SHORTEN: full round-trip (ns__local -> full URI)
+  - KEEP:    full round-trip (stored as full URI)
+  - MAP:     partial (mapped names may not be reversible)
+  - IGNORE:  local names only stored; URIRef("localName") is returned, which
+             is not a valid absolute URI.  This is a known limitation.
+"""
+
+from rdflib import URIRef
+from rdflib.term import BNode
+
+BNODE_PREFIX = "bnode://"
+
+
+def expand_uri(value: str, prefix_map: dict) -> URIRef | BNode:
+    """
+    Expand a shortened property/label name or full URI back to an rdflib term.
+
+    Args:
+        value: The stored string — may be a bnode URI, full URI, ns__local
+               shortened form, or bare local name (IGNORE mode).
+        prefix_map: Mapping of {prefix_name -> namespace_uri_string},
+                    e.g. {"rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"}.
+
+    Returns:
+        BNode if value starts with BNODE_PREFIX,
+        URIRef expanded from ns__local if prefix found,
+        URIRef(value) otherwise (full URI or bare local name).
+    """
+    if value.startswith(BNODE_PREFIX):
+        return BNode(value[len(BNODE_PREFIX):])
+    if "://" in value:
+        return URIRef(value)
+    # Try to expand ns__localName → full URI
+    if "__" in value:
+        parts = value.split("__", 1)
+        prefix, local = parts[0], parts[1]
+        if prefix in prefix_map:
+            return URIRef(f"{prefix_map[prefix]}{local}")
+    # Can't expand (IGNORE mode stores local parts only, or unknown prefix).
+    # Return as-is; this may not be a valid absolute URI.
+    return URIRef(value)
+
+
+def neo4j_value_to_literal(value, prop_key: str = None):
+    """
+    Convert a Neo4j property value back to an rdflib Literal (or list thereof).
+
+    Args:
+        value: The Neo4j property value.
+        prop_key: The property key (unused, kept for future type hints).
+
+    Returns:
+        An rdflib Literal, or a list of Literals for multi-value properties.
+
+    Notes:
+        - bool is checked before int because bool is a subclass of int in Python.
+        - Strings with "^^<uri>" or "@<lang>" suffixes are decoded back to
+          typed/lang-tagged literals.  These encodings are produced by the
+          XSD coercion layer (feat/52) when keep_custom_data_types or
+          keep_lang_tag is enabled.  The heuristic is best-effort; strings
+          that happen to contain "^^" will be misparsed.
+    """
+    from rdflib import Literal, XSD
+
+    # bool must come before int (bool is a subclass of int)
+    if isinstance(value, bool):
+        return Literal(value, datatype=XSD.boolean)
+    if isinstance(value, int):
+        return Literal(value, datatype=XSD.integer)
+    if isinstance(value, float):
+        return Literal(value, datatype=XSD.double)
+    if isinstance(value, list):
+        return [neo4j_value_to_literal(v, prop_key) for v in value]
+
+    # Try neo4j temporal types
+    try:
+        from neo4j.time import Date, DateTime, Duration
+        import datetime
+        if isinstance(value, Date):
+            return Literal(
+                datetime.date(value.year, value.month, value.day),
+                datatype=XSD.date,
+            )
+        if isinstance(value, DateTime):
+            return Literal(str(value), datatype=XSD.dateTime)
+        if isinstance(value, Duration):
+            return Literal(str(value), datatype=XSD.duration)
+    except ImportError:
+        pass
+
+    # String: check for encoded lang tag or custom datatype
+    s = str(value)
+    if "^^" in s:
+        val, dtype = s.rsplit("^^", 1)
+        return Literal(val, datatype=URIRef(dtype))
+    if "@" in s and not s.startswith("http"):
+        val, lang = s.rsplit("@", 1)
+        if 1 <= len(lang) <= 8 and lang.replace("-", "").isalpha():
+            return Literal(val, lang=lang)
+    return Literal(s)

--- a/rdflib_neo4j/query_composers/ExportQueryComposer.py
+++ b/rdflib_neo4j/query_composers/ExportQueryComposer.py
@@ -1,0 +1,53 @@
+class ExportQueryComposer:
+    """Generates Cypher queries for reading RDF triples from Neo4j."""
+
+    @staticmethod
+    def all_nodes_query() -> str:
+        """Fetch all Resource nodes with their props and labels."""
+        return (
+            "MATCH (n:Resource) "
+            "RETURN n.uri AS uri, "
+            "       [l IN labels(n) WHERE l <> 'Resource'] AS extra_labels, "
+            "       properties(n) AS props"
+        )
+
+    @staticmethod
+    def node_by_uri_query() -> str:
+        """Fetch a specific Resource node."""
+        return (
+            "MATCH (n:Resource {uri: $uri}) "
+            "RETURN n.uri AS uri, "
+            "       [l IN labels(n) WHERE l <> 'Resource'] AS extra_labels, "
+            "       properties(n) AS props"
+        )
+
+    @staticmethod
+    def all_relationships_query() -> str:
+        """Fetch all relationships between Resource nodes."""
+        return (
+            "MATCH (a:Resource)-[r]->(b:Resource) "
+            "RETURN a.uri AS from_uri, type(r) AS rel_type, b.uri AS to_uri"
+        )
+
+    @staticmethod
+    def relationships_from_uri_query() -> str:
+        """Fetch relationships from a specific subject."""
+        return (
+            "MATCH (a:Resource {uri: $uri})-[r]->(b:Resource) "
+            "RETURN a.uri AS from_uri, type(r) AS rel_type, b.uri AS to_uri"
+        )
+
+    @staticmethod
+    def count_query() -> str:
+        """
+        Approximate triple count: sum of property triples (props - uri), label triples,
+        and relationship triples.
+
+        Note: This is an approximation that sums per-node costs with a relationship count.
+        """
+        return (
+            "MATCH (n:Resource) "
+            "WITH sum(size(keys(n)) - 1 + size([l IN labels(n) WHERE l <> 'Resource'])) AS node_triples "
+            "MATCH ()-[r]->() "
+            "RETURN node_triples + count(r) AS cnt"
+        )

--- a/test/unit/test_triples.py
+++ b/test/unit/test_triples.py
@@ -1,0 +1,303 @@
+"""
+Unit tests for the triples(), __len__(), and __iter__() read interface,
+plus expander.py helpers.
+
+All tests use a mocked Neo4j session — no real database connection needed.
+"""
+from unittest.mock import MagicMock
+
+from rdflib import URIRef, Literal, RDF, XSD
+from rdflib.term import BNode
+
+from rdflib_neo4j.config.Neo4jStoreConfig import Neo4jStoreConfig
+from rdflib_neo4j.config.const import HANDLE_VOCAB_URI_STRATEGY
+from rdflib_neo4j.expander import expand_uri, neo4j_value_to_literal, BNODE_PREFIX
+
+EX = "http://example.org/"
+RDF_NS = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+FOAF_NS = "http://xmlns.com/foaf/0.1/"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_store(strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE):
+    """
+    Build a Neo4jStore with a mocked driver/session.
+
+    We pass auth_data=None and supply a driver mock so Neo4jStore does not
+    require real credentials.  The __open flag is set directly to bypass the
+    open() call that needs a real DB connection.
+    """
+    from rdflib_neo4j.Neo4jStore import Neo4jStore
+
+    config = Neo4jStoreConfig(
+        auth_data=None,
+        handle_vocab_uri_strategy=strategy,
+    )
+    mock_driver = MagicMock()
+    store = Neo4jStore(config=config, neo4j_driver=mock_driver)
+    store.session = MagicMock()
+    # Directly set the private attribute that is_open() reads
+    store._Neo4jStore__open = True
+    return store
+
+
+def _mock_run(store, *result_sequences):
+    """
+    Configure store.session.run() to return successive mock result objects.
+
+    Each item in result_sequences is a list of dicts (rows) for one run() call.
+    """
+    def make_result(rows):
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(return_value=iter(rows))
+        return mock_result
+
+    store.session.run.side_effect = [make_result(rows) for rows in result_sequences]
+
+
+# ---------------------------------------------------------------------------
+# Tests for expand_uri
+# ---------------------------------------------------------------------------
+
+class TestExpandUri:
+    def test_bnode(self):
+        result = expand_uri(f"{BNODE_PREFIX}xyz", {})
+        assert result == BNode("xyz")
+        assert isinstance(result, BNode)
+
+    def test_full_uri(self):
+        result = expand_uri("http://example.org/foo", {})
+        assert result == URIRef("http://example.org/foo")
+        assert isinstance(result, URIRef)
+
+    def test_shortened_ns_local(self):
+        pm = {"rdf": RDF_NS}
+        result = expand_uri("rdf__type", pm)
+        assert result == URIRef(f"{RDF_NS}type")
+
+    def test_shortened_unknown_prefix_falls_back(self):
+        # Unknown prefix → returned as-is (IGNORE mode fallback)
+        result = expand_uri("unknown__foo", {})
+        assert result == URIRef("unknown__foo")
+
+    def test_bare_local_name_fallback(self):
+        # IGNORE mode stores bare local names; we return URIRef as-is
+        result = expand_uri("name", {})
+        assert result == URIRef("name")
+
+    def test_https_uri(self):
+        result = expand_uri("https://schema.org/name", {})
+        assert result == URIRef("https://schema.org/name")
+
+
+# ---------------------------------------------------------------------------
+# Tests for neo4j_value_to_literal
+# ---------------------------------------------------------------------------
+
+class TestNeo4jValueToLiteral:
+    def test_int(self):
+        result = neo4j_value_to_literal(42)
+        assert result == Literal(42, datatype=XSD.integer)
+
+    def test_float(self):
+        result = neo4j_value_to_literal(3.14)
+        assert result == Literal(3.14, datatype=XSD.double)
+
+    def test_bool_true(self):
+        result = neo4j_value_to_literal(True)
+        assert result == Literal(True, datatype=XSD.boolean)
+
+    def test_bool_false(self):
+        result = neo4j_value_to_literal(False)
+        assert result == Literal(False, datatype=XSD.boolean)
+
+    def test_bool_before_int(self):
+        # True would be Literal(1) if int were checked first — ensure correct order
+        result = neo4j_value_to_literal(True)
+        assert result.datatype == XSD.boolean
+
+    def test_string(self):
+        result = neo4j_value_to_literal("hello")
+        assert result == Literal("hello")
+
+    def test_list(self):
+        result = neo4j_value_to_literal([1, 2])
+        assert result == [Literal(1, datatype=XSD.integer), Literal(2, datatype=XSD.integer)]
+
+    def test_string_with_custom_type(self):
+        result = neo4j_value_to_literal("2024-01-01^^http://www.w3.org/2001/XMLSchema#date")
+        assert result.datatype == XSD.date
+        assert str(result) == "2024-01-01"
+
+    def test_string_with_lang_tag(self):
+        result = neo4j_value_to_literal("hello@en")
+        assert result.language == "en"
+        assert str(result) == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Tests for Neo4jStore.triples()
+# ---------------------------------------------------------------------------
+
+class TestTriples:
+    def _make_node_record(self, uri, labels=None, props=None):
+        """Helper to build a dict resembling a Neo4j record for a node query."""
+        rec = MagicMock()
+        rec.__getitem__ = lambda self, key: {
+            "uri": uri,
+            "extra_labels": labels or [],
+            "props": dict({"uri": uri}, **(props or {})),
+        }[key]
+        return rec
+
+    def _make_rel_record(self, from_uri, rel_type, to_uri):
+        rec = MagicMock()
+        rec.__getitem__ = lambda self, key: {
+            "from_uri": from_uri,
+            "rel_type": rel_type,
+            "to_uri": to_uri,
+        }[key]
+        return rec
+
+    def test_wildcard_yields_property_triple(self):
+        store = make_store()
+        node_rec = self._make_node_record(
+            f"{EX}donna",
+            props={"name": "Donna"},
+        )
+        _mock_run(store, [node_rec], [])  # nodes, then rels
+        results = list(store.triples((None, None, None)))
+        # Should yield at least one property triple
+        subjects = [t for (t, _) in results]
+        assert any(
+            s == URIRef(f"{EX}donna") and str(o) == "Donna"
+            for (s, p, o) in subjects
+        )
+
+    def test_wildcard_yields_rdf_type_triple(self):
+        store = make_store(strategy=HANDLE_VOCAB_URI_STRATEGY.KEEP)
+        node_rec = self._make_node_record(
+            f"{EX}donna",
+            labels=["Person"],
+        )
+        _mock_run(store, [node_rec], [])
+        results = list(store.triples((None, None, None)))
+        triples_only = [t for (t, _) in results]
+        assert any(p == RDF.type for (s, p, o) in triples_only)
+
+    def test_wildcard_yields_relationship_triple(self):
+        store = make_store(strategy=HANDLE_VOCAB_URI_STRATEGY.KEEP)
+        rel_rec = self._make_rel_record(
+            f"{EX}donna",
+            f"{EX}knows",
+            f"{EX}bob",
+        )
+        _mock_run(store, [], [rel_rec])  # no node props, one rel
+        results = list(store.triples((None, None, None)))
+        triples_only = [t for (t, _) in results]
+        assert (URIRef(f"{EX}donna"), URIRef(f"{EX}knows"), URIRef(f"{EX}bob")) in triples_only
+
+    def test_subject_bound_uses_specific_query(self):
+        store = make_store()
+        node_rec = self._make_node_record(f"{EX}donna")
+        _mock_run(store, [node_rec], [])
+        list(store.triples((URIRef(f"{EX}donna"), None, None)))
+        # First run() call should use the node_by_uri_query with uri param
+        first_call_kwargs = store.session.run.call_args_list[0]
+        assert first_call_kwargs[1].get("uri") == f"{EX}donna" or \
+               (len(first_call_kwargs[0]) > 1 and first_call_kwargs[0][1] == f"{EX}donna")
+
+    def test_bnode_subject_is_converted_to_bnode_uri(self):
+        store = make_store()
+        bn = BNode("xyz")
+        _mock_run(store, [], [])
+        list(store.triples((bn, None, None)))
+        first_call = store.session.run.call_args_list[0]
+        # The URI passed should be bnode://xyz
+        passed_uri = first_call[1].get("uri", "") or (
+            first_call[0][1] if len(first_call[0]) > 1 else ""
+        )
+        assert passed_uri == f"{BNODE_PREFIX}xyz"
+
+    def test_rdf_type_predicate_skips_rel_query(self):
+        """When p=rdf:type, relationship queries should not be issued."""
+        store = make_store()
+        node_rec = self._make_node_record(f"{EX}donna", labels=["Person"])
+        _mock_run(store, [node_rec])  # only one run() call expected
+        list(store.triples((URIRef(f"{EX}donna"), RDF.type, None)))
+        # Only the node query should have been called (no rel query)
+        assert store.session.run.call_count == 1
+
+    def test_literal_object_skips_rel_query(self):
+        """When o is a Literal, relationship queries should not be issued."""
+        store = make_store()
+        node_rec = self._make_node_record(f"{EX}donna", props={"name": "Donna"})
+        _mock_run(store, [node_rec])  # only one run() call expected
+        list(store.triples((URIRef(f"{EX}donna"), None, Literal("Donna"))))
+        assert store.session.run.call_count == 1
+
+    def test_o_is_uriref_includes_node_triples(self):
+        """(None, None, URIRef) should still yield rdf:type triples (fix for spec bug)."""
+        store = make_store(strategy=HANDLE_VOCAB_URI_STRATEGY.KEEP)
+        target = URIRef(f"{EX}Person")
+        node_rec = self._make_node_record(f"{EX}donna", labels=[f"{EX}Person"])
+        _mock_run(store, [node_rec], [])
+        results = list(store.triples((None, None, target)))
+        triples_only = [t for (t, _) in results]
+        assert (URIRef(f"{EX}donna"), RDF.type, target) in triples_only
+
+
+# ---------------------------------------------------------------------------
+# Tests for __len__
+# ---------------------------------------------------------------------------
+
+class TestLen:
+    def test_len_returns_count(self):
+        store = make_store()
+        mock_result = MagicMock()
+        mock_single = {"cnt": 42}
+        mock_result.single.return_value = mock_single
+        store.session.run.return_value = mock_result
+        assert len(store) == 42
+
+    def test_len_returns_zero_when_no_records(self):
+        store = make_store()
+        mock_result = MagicMock()
+        mock_result.single.return_value = None
+        store.session.run.return_value = mock_result
+        assert len(store) == 0
+
+    def test_len_returns_zero_when_closed(self):
+        store = make_store()
+        store._Neo4jStore__open = False
+        assert len(store) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests for __iter__
+# ---------------------------------------------------------------------------
+
+class TestIter:
+    def test_iter_delegates_to_triples(self):
+        """__iter__ should return the same triples as triples((None,None,None))."""
+        store = make_store(strategy=HANDLE_VOCAB_URI_STRATEGY.KEEP)
+
+        def make_node_result():
+            rec = MagicMock()
+            rec.__getitem__ = lambda self, key: {
+                "uri": f"{EX}donna",
+                "extra_labels": [],
+                "props": {"uri": f"{EX}donna", "name": "Donna"},
+            }[key]
+            result = MagicMock()
+            result.__iter__ = MagicMock(return_value=iter([rec]))
+            return result
+
+        # iter calls triples((None,None,None)) which does 2 run() calls
+        store.session.run.side_effect = [make_node_result(), MagicMock(__iter__=lambda s: iter([]))]
+        triples_list = list(store.__iter__())
+        assert len(triples_list) > 0
+        assert all(isinstance(t, tuple) and len(t) == 3 for t in triples_list)


### PR DESCRIPTION
## Summary

- Implements `triples()` with full subject/predicate/object filter combinations via `ExportQueryComposer` Cypher queries
- Implements `__len__()` (count query) and `__iter__()` (delegates to `triples()`)
- Adds `expander.py`: converts Neo4j node/relationship properties back to RDF terms (URIRef, BNode, Literal) including temporal types
- Unlocks `graph.serialize()` and SPARQL queries against the store

**Depends on:** #72 (feat/52-xsd-coercion)

## Test plan

- [ ] Unit tests: 27 tests covering all triple filter patterns, bnode round-trips, literal type expansion, len/iter
- [ ] Integration: load triples → serialize back to Turtle → compare with original

Closes #55