### PR TITLE
feat(#56): add handleRDFTypes NODES and LABELS_AND_NODES modes

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -2,5 +2,6 @@
 * xref:gettingstarted.adoc[Getting Started]
 * xref:neo4jstore.adoc[Neo4j Store]
 * xref:neo4jstoreconfig.adoc[Store Configuration]
+* xref:handle-rdf-types.adoc[Handling rdf:type]
 * xref:examples.adoc[Examples]
 * xref:contributing.adoc[Contributing]

--- a/docs/modules/ROOT/pages/handle-rdf-types.adoc
+++ b/docs/modules/ROOT/pages/handle-rdf-types.adoc
@@ -1,0 +1,165 @@
+= Handling rdf:type Triples
+[.procedures, opts=header]
+
+The `handle_rdf_types` configuration parameter controls how `rdf:type` triples are persisted in Neo4j.
+By default, rdflib-neo4j mirrors the behaviour of https://neo4j.com/labs/neosemantics/[neosemantics (n10s)]:
+an `rdf:type` triple causes the object's local name to be added as a Neo4j label on the subject node.
+Two additional modes let you store types as explicit graph relationships instead of (or in addition to) labels.
+
+== Strategy Values
+
+The behaviour is controlled by the `HandleRDFTypesStrategy` enum (imported from `rdflib_neo4j.config.const`).
+
+|===
+| Value | Behaviour
+
+| `LABELS` *(default)*
+| The object's local name is added as a Neo4j label on the subject node.
+  No relationship is created. Mirrors n10s `handleRDFTypes=LABELS`.
+
+| `NODES`
+| A `(:Resource {uri: "<class URI>"})-[:rdf__type]->` relationship is created.
+  A `:Class` node is also merged for the object URI.
+  No label is added to the subject.
+
+| `LABELS_AND_NODES`
+| Both a Neo4j label *and* the `[:rdf__type]` relationship / `:Class` node are created.
+|===
+
+== Worked Example
+
+Given the triple:
+
+[source,turtle]
+----
+ex:fido  rdf:type  ex:Dog .
+----
+
+=== LABELS (default)
+
+The subject node receives the label `:Dog`.
+No relationship is stored.
+
+Resulting graph shape:
+
+[source,cypher]
+----
+(:Resource:Dog {uri: "http://www.example.org/indiv/fido"})
+----
+
+Query to retrieve the type:
+
+[source,cypher]
+----
+MATCH (n:Resource {uri: "http://www.example.org/indiv/fido"})
+RETURN labels(n) AS types
+----
+
+=== NODES
+
+A `:Class` node is merged for `ex:Dog` and a `[:rdf__type]` relationship is created.
+The subject receives *no* extra label.
+
+Resulting graph shape:
+
+[source,cypher]
+----
+(:Resource {uri: "http://www.example.org/indiv/fido"})
+  -[:rdf__type]->
+(:Resource:Class {uri: "http://www.example.org/indiv/Dog"})
+----
+
+Query to retrieve the type:
+
+[source,cypher]
+----
+MATCH (:Resource {uri: "http://www.example.org/indiv/fido"})
+      -[:rdf__type]->(c:Class)
+RETURN c.uri AS type
+----
+
+=== LABELS_AND_NODES
+
+Both the label *and* the relationship are created simultaneously.
+
+Resulting graph shape:
+
+[source,cypher]
+----
+(:Resource:Dog {uri: "http://www.example.org/indiv/fido"})
+  -[:rdf__type]->
+(:Resource:Class {uri: "http://www.example.org/indiv/Dog"})
+----
+
+Query to retrieve the type (label approach):
+
+[source,cypher]
+----
+MATCH (n:Resource {uri: "http://www.example.org/indiv/fido"})
+RETURN labels(n) AS types
+----
+
+Query to retrieve the type (relationship approach):
+
+[source,cypher]
+----
+MATCH (:Resource {uri: "http://www.example.org/indiv/fido"})
+      -[:rdf__type]->(c:Class)
+RETURN c.uri AS type
+----
+
+== Comparison Table
+
+|===
+| Strategy | Subject gets label | [:rdf__type] relationship | :Class node created
+
+| `LABELS`
+| yes
+| no
+| no
+
+| `NODES`
+| no
+| yes
+| yes
+
+| `LABELS_AND_NODES`
+| yes
+| yes
+| yes
+|===
+
+== Configuration Example
+
+[source,python]
+----
+from rdflib_neo4j import Neo4jStoreConfig, Neo4jStore, HANDLE_VOCAB_URI_STRATEGY
+from rdflib_neo4j.config.const import HandleRDFTypesStrategy
+from rdflib import ConjunctiveGraph
+
+config = Neo4jStoreConfig(
+    auth_data={
+        "uri": "bolt://localhost:7687",
+        "database": "neo4j",
+        "user": "neo4j",
+        "pwd": "password",
+    },
+    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.SHORTEN,
+    handle_rdf_types=HandleRDFTypesStrategy.LABELS_AND_NODES,
+)
+
+store = Neo4jStore(config=config)
+g = ConjunctiveGraph(store=store)
+g.open(config, create=True)
+g.parse("data.ttl", format="turtle")
+----
+
+== Compatibility Note
+
+The `LABELS` strategy (the default) matches the behaviour of n10s when configured with
+`handleRDFTypes=LABELS` in a `GraphConfig`.  If you are migrating data from n10s or
+need interoperability with n10s tooling, `LABELS` is the correct choice.
+
+Use `NODES` or `LABELS_AND_NODES` when you need to traverse `rdf:type` as a first-class
+graph relationship — for example, to support SPARQL queries that treat type assertions
+as edges, or to retain the full Class hierarchy as explicit nodes in your graph.

--- a/rdflib_neo4j/Neo4jStore.py
+++ b/rdflib_neo4j/Neo4jStore.py
@@ -48,6 +48,7 @@ class Neo4jStore(Store):
         self.multival_props_predicates = config.multival_props_names
         self._dynamic_ns_map: dict = {}   # namespace_uri -> "nsN" prefix
         self._dynamic_ns_counter: list = [0]  # mutable counter (passed by ref to utils)
+        self.handle_rdf_types_strategy = config.handle_rdf_types_strategy
 
     def open(self, configuration, create=True):
         """
@@ -240,6 +241,7 @@ class Neo4jStore(Store):
         Stores the relationships of the current subject in the respective relationship buffer.
 
         This function adds the relationships of the current subject to the relationship buffer for later insertion into the Neo4j database.
+        For NODES/LABELS_AND_NODES strategies, also queues :Class node creation for rdf:type targets.
         """
         rel_types_and_relationships = self.current_subject.extract_rels()
         if self.current_subject.extract_rels():
@@ -249,6 +251,21 @@ class Neo4jStore(Store):
                 for to_node in rel_types_and_relationships[rel_type]:
                     self.rel_buffer[rel_type].add_query_param(from_node=self.current_subject.uri, to_node=to_node)
                     self.rel_buffer_size += 1
+
+        # Create :Class nodes for NODES/LABELS_AND_NODES mode
+        # Note: the rel buffer may flush before the node buffer in some cases, but
+        # RelationshipQueryComposer will MERGE the target as :Resource; the Class label
+        # is then added when the node buffer flushes — idempotent via MERGE semantics.
+        for class_uri in self.current_subject.extract_rdf_type_class_uris():
+            class_label_key = f"Class:{class_uri}"
+            if class_label_key not in self.node_buffer:
+                self.node_buffer[class_label_key] = NodeQueryComposer(
+                    labels={"Class"},
+                    handle_multival_strategy=self.handle_multival_strategy,
+                    multival_props_predicates=self.multival_props_predicates
+                )
+            self.node_buffer[class_label_key].add_query_param({"uri": class_uri})
+            self.node_buffer_size += 1
 
     def __store_current_subject(self):
         """
@@ -268,7 +285,8 @@ class Neo4jStore(Store):
                            handle_multival_strategy=self.handle_multival_strategy,
                            multival_props_names=self.multival_props_predicates,
                            dynamic_ns_map=self._dynamic_ns_map,
-                           dynamic_ns_counter=self._dynamic_ns_counter)
+                           dynamic_ns_counter=self._dynamic_ns_counter,
+                           handle_rdf_types_strategy=self.handle_rdf_types_strategy)
 
     def __check_current_subject(self, subject):
         """

--- a/rdflib_neo4j/Neo4jTriple.py
+++ b/rdflib_neo4j/Neo4jTriple.py
@@ -4,7 +4,7 @@ from typing import Dict, Set, List
 from rdflib import Literal, URIRef, RDF
 from rdflib.term import BNode, Node
 from rdflib_neo4j.utils import bnode_to_uri, handle_vocab_uri
-from rdflib_neo4j.config.const import HANDLE_VOCAB_URI_STRATEGY, HANDLE_MULTIVAL_STRATEGY
+from rdflib_neo4j.config.const import HANDLE_VOCAB_URI_STRATEGY, HANDLE_MULTIVAL_STRATEGY, HandleRDFTypesStrategy
 
 
 class Neo4jTriple:
@@ -24,7 +24,8 @@ class Neo4jTriple:
                  multival_props_names: List[str],
                  prefixes: Dict[str, str],
                  dynamic_ns_map: dict = None,
-                 dynamic_ns_counter: list = None):
+                 dynamic_ns_counter: list = None,
+                 handle_rdf_types_strategy: HandleRDFTypesStrategy = HandleRDFTypesStrategy.LABELS):
         """
         Constructor for Neo4jTriple.
 
@@ -36,6 +37,7 @@ class Neo4jTriple:
             prefixes: A dictionary of namespace prefixes used for vocabulary URI handling.
             dynamic_ns_map: (SHORTEN mode) dict mapping unknown namespace URIs to auto-generated nsN prefixes.
             dynamic_ns_counter: (SHORTEN mode) single-element list holding the next nsN counter value.
+            handle_rdf_types_strategy: The strategy to handle rdf:type triples.
         """
         self.uri = uri
         self.labels = set()
@@ -48,6 +50,8 @@ class Neo4jTriple:
         self.prefixes = prefixes
         self.dynamic_ns_map = dynamic_ns_map if dynamic_ns_map is not None else {}
         self.dynamic_ns_counter = dynamic_ns_counter if dynamic_ns_counter is not None else [0]
+        self.handle_rdf_types_strategy = handle_rdf_types_strategy
+        self._rdf_type_class_uris: set = set()
 
     def add_label(self, label: str):
         """
@@ -136,6 +140,16 @@ class Neo4jTriple:
         """
         return {key: list(value) for key, value in self.relationships.items()}
 
+    def extract_rdf_type_class_uris(self) -> set:
+        """
+        Returns the set of Class URIs encountered via rdf:type triples when using
+        NODES or LABELS_AND_NODES strategies. These URIs need corresponding :Class nodes.
+
+        Returns:
+            set: The set of class URIs.
+        """
+        return self._rdf_type_class_uris
+
     def handle_vocab_uri(self, mappings, predicate):
         """
         Handles a vocabulary URI according to the specified strategy, defined using the HANDLE_VOCAB_URI_STRATEGY Enum.
@@ -179,9 +193,19 @@ class Neo4jTriple:
             else:
                 self.add_prop(prop_name, value)
 
-        # Getting a label
+        # Getting a label / class node depending on strategy
         elif predicate == RDF.type:
-            self.add_label(self.handle_vocab_uri(mappings, object))
+            class_uri = self.handle_vocab_uri(mappings, object)
+            strategy = self.handle_rdf_types_strategy
+
+            if strategy in (HandleRDFTypesStrategy.LABELS, HandleRDFTypesStrategy.LABELS_AND_NODES):
+                self.add_label(class_uri)
+
+            if strategy in (HandleRDFTypesStrategy.NODES, HandleRDFTypesStrategy.LABELS_AND_NODES):
+                # Record as relationship: (subject)-[:rdf__type]->(class_node)
+                # Use the full class URI as the target node URI so the Class node is merged on full URI
+                self.add_rel("rdf__type", object)
+                self._rdf_type_class_uris.add(object)
 
         # Getting its relationships
         else:

--- a/rdflib_neo4j/config/Neo4jStoreConfig.py
+++ b/rdflib_neo4j/config/Neo4jStoreConfig.py
@@ -3,7 +3,7 @@ from rdflib import Namespace, URIRef
 from rdflib_neo4j.config.const import (
     DEFAULT_PREFIXES,
     PrefixNotFoundException,
-    HANDLE_VOCAB_URI_STRATEGY, HANDLE_MULTIVAL_STRATEGY
+    HANDLE_VOCAB_URI_STRATEGY, HANDLE_MULTIVAL_STRATEGY, HandleRDFTypesStrategy
 )
 
 class Neo4jStoreConfig:
@@ -38,7 +38,8 @@ class Neo4jStoreConfig:
             batch_size=5000,
             handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.SHORTEN,
             handle_multival_strategy=HANDLE_MULTIVAL_STRATEGY.OVERWRITE,
-            multival_props_names: List[Tuple[str, str]] = []
+            multival_props_names: List[Tuple[str, str]] = [],
+            handle_rdf_types_strategy: HandleRDFTypesStrategy = HandleRDFTypesStrategy.LABELS
     ):
         self.default_prefixes = DEFAULT_PREFIXES
         self.auth_data = auth_data
@@ -53,6 +54,7 @@ class Neo4jStoreConfig:
         self.multival_props_names = []
         for prop_name in multival_props_names:
             self.set_multival_prop_name(prefix_name=prop_name[0], prop_name=prop_name[1])
+        self.handle_rdf_types_strategy = handle_rdf_types_strategy
 
     def set_handle_vocab_uri_strategy(self, val: HANDLE_VOCAB_URI_STRATEGY):
         """

--- a/rdflib_neo4j/config/const.py
+++ b/rdflib_neo4j/config/const.py
@@ -57,7 +57,7 @@ class CypherMultipleTypesMultiValueException(Exception):
         super().__init__()
 
     def __str__(self):
-        return f"""Values of a multivalued property must have the same datatype."""
+        return """Values of a multivalued property must have the same datatype."""
 
 NEO4J_DRIVER_MULTIPLE_TYPE_ERROR_MESSAGE = """{code: Neo.ClientError.Statement.TypeError} {message: Neo4j only supports a subset of Cypher types for storage as singleton or array properties. Please refer to section cypher/syntax/values of the manual for more details.}"""
 NEO4J_DRIVER_DICT_MESSAGE = {NEO4J_DRIVER_MULTIPLE_TYPE_ERROR_MESSAGE: CypherMultipleTypesMultiValueException}
@@ -91,3 +91,18 @@ class HANDLE_MULTIVAL_STRATEGY(Enum):
     """
     OVERWRITE = 1  # Strategy to overwrite multiple values
     ARRAY = 2  # Strategy to treat multiple values as an array
+
+
+class HandleRDFTypesStrategy(Enum):
+    """
+    Strategy for handling rdf:type triples.
+
+    - LABELS: add Neo4j label (default, matches existing behaviour)
+    - NODES: create :Class node + [:rdf__type] relationship (no label)
+    - LABELS_AND_NODES: both label and Class node + relationship
+
+    Values match n10s GraphConfig canonical strings.
+    """
+    LABELS = "LABELS"
+    NODES = "NODES"
+    LABELS_AND_NODES = "LABELS_AND_NODES"

--- a/test/unit/test_handle_rdf_types.py
+++ b/test/unit/test_handle_rdf_types.py
@@ -1,0 +1,128 @@
+"""
+Unit tests for HandleRDFTypesStrategy — no Neo4j connection required.
+Exercises Neo4jTriple.parse_triple for LABELS, NODES, and LABELS_AND_NODES modes.
+"""
+from rdflib import URIRef, RDF
+from rdflib_neo4j.Neo4jTriple import Neo4jTriple
+from rdflib_neo4j.config.const import (
+    HANDLE_VOCAB_URI_STRATEGY,
+    HANDLE_MULTIVAL_STRATEGY,
+    HandleRDFTypesStrategy,
+)
+from rdflib_neo4j.config.Neo4jStoreConfig import Neo4jStoreConfig
+
+EX = "http://example.org/"
+SUBJECT = URIRef(f"{EX}thing")
+PERSON_CLASS = URIRef(f"{EX}Person")
+
+
+def make_triple(strategy=HandleRDFTypesStrategy.LABELS):
+    return Neo4jTriple(
+        uri=SUBJECT,
+        prefixes={},
+        handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,
+        handle_multival_strategy=HANDLE_MULTIVAL_STRATEGY.OVERWRITE,
+        multival_props_names=[],
+        handle_rdf_types_strategy=strategy,
+    )
+
+
+def rdf_type_triple():
+    """Returns an (subject, rdf:type, ex:Person) triple."""
+    return (SUBJECT, RDF.type, PERSON_CLASS)
+
+
+# ---------------------------------------------------------------------------
+# LABELS strategy (default)
+# ---------------------------------------------------------------------------
+
+class TestLabelsStrategy:
+    def test_label_added(self):
+        triple = make_triple(HandleRDFTypesStrategy.LABELS)
+        triple.parse_triple(rdf_type_triple(), {})
+        assert "Person" in triple.labels
+
+    def test_no_rel_added(self):
+        triple = make_triple(HandleRDFTypesStrategy.LABELS)
+        triple.parse_triple(rdf_type_triple(), {})
+        assert triple.extract_rels() == {}
+
+    def test_class_uris_empty(self):
+        triple = make_triple(HandleRDFTypesStrategy.LABELS)
+        triple.parse_triple(rdf_type_triple(), {})
+        assert triple.extract_rdf_type_class_uris() == set()
+
+
+# ---------------------------------------------------------------------------
+# NODES strategy
+# ---------------------------------------------------------------------------
+
+class TestNodesStrategy:
+    def test_no_label_added(self):
+        triple = make_triple(HandleRDFTypesStrategy.NODES)
+        triple.parse_triple(rdf_type_triple(), {})
+        assert triple.labels == set()
+
+    def test_rel_added(self):
+        triple = make_triple(HandleRDFTypesStrategy.NODES)
+        triple.parse_triple(rdf_type_triple(), {})
+        rels = triple.extract_rels()
+        assert "rdf__type" in rels
+        assert PERSON_CLASS in rels["rdf__type"]
+
+    def test_class_uri_tracked(self):
+        triple = make_triple(HandleRDFTypesStrategy.NODES)
+        triple.parse_triple(rdf_type_triple(), {})
+        assert PERSON_CLASS in triple.extract_rdf_type_class_uris()
+
+
+# ---------------------------------------------------------------------------
+# LABELS_AND_NODES strategy
+# ---------------------------------------------------------------------------
+
+class TestLabelsAndNodesStrategy:
+    def test_label_added(self):
+        triple = make_triple(HandleRDFTypesStrategy.LABELS_AND_NODES)
+        triple.parse_triple(rdf_type_triple(), {})
+        assert "Person" in triple.labels
+
+    def test_rel_added(self):
+        triple = make_triple(HandleRDFTypesStrategy.LABELS_AND_NODES)
+        triple.parse_triple(rdf_type_triple(), {})
+        rels = triple.extract_rels()
+        assert "rdf__type" in rels
+        assert PERSON_CLASS in rels["rdf__type"]
+
+    def test_class_uri_tracked(self):
+        triple = make_triple(HandleRDFTypesStrategy.LABELS_AND_NODES)
+        triple.parse_triple(rdf_type_triple(), {})
+        assert PERSON_CLASS in triple.extract_rdf_type_class_uris()
+
+
+# ---------------------------------------------------------------------------
+# Enum canonical string values (match n10s GraphConfig)
+# ---------------------------------------------------------------------------
+
+class TestEnumValues:
+    def test_labels_value(self):
+        assert HandleRDFTypesStrategy.LABELS.value == "LABELS"
+
+    def test_nodes_value(self):
+        assert HandleRDFTypesStrategy.NODES.value == "NODES"
+
+    def test_labels_and_nodes_value(self):
+        assert HandleRDFTypesStrategy.LABELS_AND_NODES.value == "LABELS_AND_NODES"
+
+
+# ---------------------------------------------------------------------------
+# Default strategy in Neo4jStoreConfig
+# ---------------------------------------------------------------------------
+
+class TestNeo4jStoreConfigDefault:
+    def test_default_strategy_is_labels(self):
+        config = Neo4jStoreConfig()
+        assert config.handle_rdf_types_strategy == HandleRDFTypesStrategy.LABELS
+
+    def test_custom_strategy_stored(self):
+        config = Neo4jStoreConfig(handle_rdf_types_strategy=HandleRDFTypesStrategy.NODES)
+        assert config.handle_rdf_types_strategy == HandleRDFTypesStrategy.NODES


### PR DESCRIPTION
## Summary

- Introduces `HandleRDFTypesStrategy` enum with three modes: `LABELS` (default), `NODES`, `LABELS_AND_NODES`
- `NODES`: rdf:type triples create `(subject)-[:rdf__type]->(Class)` relationships instead of labels
- `LABELS_AND_NODES`: does both — adds label AND creates the Class node relationship
- Class nodes are buffered separately (keyed by URI) and merged via `NodeQueryComposer`

**Depends on:** #73 (feat/50-shorten-modes)

## Test plan

- [ ] Unit tests: 14 tests covering all three strategies, label assignment, Class node creation, combined mode
- [ ] Integration: import with each strategy → verify correct graph shape in Neo4j

Closes #56