### PR TITLE
feat(#63): opt-in named graph / quad support

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -2,5 +2,6 @@
 * xref:gettingstarted.adoc[Getting Started]
 * xref:neo4jstore.adoc[Neo4j Store]
 * xref:neo4jstoreconfig.adoc[Store Configuration]
+* xref:named-graphs.adoc[Named Graphs / Quad Support]
 * xref:examples.adoc[Examples]
 * xref:contributing.adoc[Contributing]

--- a/docs/modules/ROOT/pages/named-graphs.adoc
+++ b/docs/modules/ROOT/pages/named-graphs.adoc
@@ -1,0 +1,242 @@
+= Named Graph / Quad Support
+
+RDF triples can be grouped into *named graphs*, turning them into *quads*: a four-element tuple of `(subject, predicate, object, graphURI)`.
+Named graphs let you track the provenance of data, partition a dataset by source or version, and query subsets of a larger store.
+
+Quad-capable RDF serialisation formats include:
+
+* **TriG** (`.trig`) — Turtle extended with named graph blocks
+* **N-Quads** (`.nq`) — newline-delimited quads, one per line
+
+== Enabling named graph support
+
+By default, `Neo4jStore` operates in *plain triple* mode — the graph context is ignored and the database enforces a uniqueness constraint on `:Resource(uri)`.
+
+To enable named graph (quad) support, pass `named_graphs=True` to `Neo4jStoreConfig`:
+
+[source,python]
+----
+from rdflib import ConjunctiveGraph, URIRef
+from rdflib_neo4j import Neo4jStoreConfig, Neo4jStore, HANDLE_VOCAB_URI_STRATEGY
+
+auth_data = {
+    "uri": "neo4j+s://your-instance.databases.neo4j.io",
+    "database": "neo4j",
+    "user": "neo4j",
+    "pwd": "your-password",
+}
+
+config = Neo4jStoreConfig(
+    auth_data=auth_data,
+    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,
+    batching=True,
+    named_graphs=True,          # <1>
+)
+
+# Use ConjunctiveGraph to hold quads
+store = Neo4jStore(config=config)
+g = ConjunctiveGraph(store=store)  # <2>
+
+# parse a TriG file — each named graph in the file maps to a separate context
+g.parse("data.trig", format="trig")
+g.close(True)
+----
+<1> Set `named_graphs=True` in the config.
+<2> Use `rdflib.ConjunctiveGraph` (or `rdflib.Dataset`) instead of plain `Graph`.
+
+=== Loading N-Quads
+
+N-Quads files are loaded the same way:
+
+[source,python]
+----
+g.parse("data.nq", format="nquads")
+g.close(True)
+----
+
+=== Inline example: loading quads from a TriG string
+
+[source,python]
+----
+from rdflib import ConjunctiveGraph, URIRef
+from rdflib_neo4j import Neo4jStoreConfig, Neo4jStore, HANDLE_VOCAB_URI_STRATEGY
+
+TRIG_DATA = """\
+@prefix ex: <http://example.org/> .
+
+GRAPH ex:graph1 {
+    ex:alice a ex:Person ;
+             ex:name "Alice" .
+}
+
+GRAPH ex:graph2 {
+    ex:bob a ex:Person ;
+           ex:name "Bob" .
+}
+"""
+
+config = Neo4jStoreConfig(
+    auth_data=auth_data,
+    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,
+    batching=True,
+    named_graphs=True,
+)
+
+store = Neo4jStore(config=config)
+g = ConjunctiveGraph(store=store)
+g.parse(data=TRIG_DATA, format="trig")
+g.close(True)
+----
+
+After loading, the Neo4j database contains *two separate* `:Resource` nodes for `ex:alice` and `ex:bob`, each carrying a `graphUri` property that identifies which named graph it came from.
+
+== How graph URIs are stored in Neo4j
+
+When `named_graphs=True`, every node and relationship written to Neo4j carries a `graphUri` string property whose value is the URI of the named graph it belongs to.
+
+The same resource URI appearing in *different* named graphs becomes *separate nodes* in Neo4j — matching n10s ContextResource / quad-import semantics.
+
+Example Neo4j node after import:
+
+[source,json]
+----
+{
+  "uri": "http://example.org/alice",
+  "name": "Alice",
+  "graphUri": "http://example.org/graph1"
+}
+----
+
+Relationships carry the same property:
+
+[source,json]
+----
+{
+  "type": "knows",
+  "graphUri": "http://example.org/graph1"
+}
+----
+
+== Schema: index instead of uniqueness constraint
+
+In default mode, `Neo4jStore` requires a uniqueness constraint on `:Resource(uri)`, because each URI maps to exactly one node.
+In named-graph mode the same URI can exist as multiple nodes (one per graph), so a uniqueness constraint would reject valid data.
+
+When `named_graphs=True`, the store creates a plain RANGE index instead:
+
+[source,cypher]
+----
+CREATE INDEX n10s_resource_uri IF NOT EXISTS FOR (r:Resource) ON (r.uri)
+----
+
+This index is created automatically when you pass `create=True` (the default) to `store.open()`.
+To create it manually:
+
+[source,cypher]
+----
+CREATE INDEX n10s_resource_uri IF NOT EXISTS FOR (r:Resource) ON (r.uri)
+----
+
+== Querying by named graph with Cypher
+
+Because `graphUri` is stored as a plain string property, filtering by named graph in Cypher uses standard property matching.
+
+=== Find all nodes in a specific named graph
+
+[source,cypher]
+----
+MATCH (n {graphUri: "http://example.org/graph1"})
+RETURN n
+----
+
+=== Find all nodes and relationships in a specific named graph
+
+[source,cypher]
+----
+MATCH (s)-[r]->(o)
+WHERE s.graphUri = "http://example.org/graph1"
+  AND r.graphUri = "http://example.org/graph1"
+RETURN s, r, o
+----
+
+=== Parameterised query (recommended)
+
+[source,cypher]
+----
+MATCH (n {graphUri: $graphUri})
+RETURN n
+----
+
+=== List all distinct named graphs
+
+[source,cypher]
+----
+MATCH (n:Resource)
+WHERE n.graphUri IS NOT NULL
+RETURN DISTINCT n.graphUri AS graph
+----
+
+== Filtering with `triples()`
+
+`Neo4jStore.triples()` accepts an optional `context` argument.
+When `named_graphs=True`, passing a graph object restricts results to triples stored in that named graph:
+
+[source,python]
+----
+from rdflib import Graph, URIRef
+
+# Retrieve only triples that belong to graph1
+graph1 = Graph(identifier=URIRef("http://example.org/graph1"))
+for triple, _ in store.triples((None, None, None), context=graph1):
+    print(triple)
+----
+
+== Graph vs ConjunctiveGraph: which to use
+
+[cols="1,1,2", options="header"]
+|===
+| Class | `named_graphs` setting | Behaviour
+
+| `rdflib.Graph`
+| `False` (default)
+| Plain triple store. Each URI maps to one node. Uniqueness constraint on `:Resource(uri)`. Context passed to `add()` is ignored.
+
+| `rdflib.ConjunctiveGraph` / `rdflib.Dataset`
+| `True`
+| Quad store. Same URI in different graphs = separate nodes. Plain RANGE index on `:Resource(uri)`. Each node/relationship carries `graphUri`.
+|===
+
+== Warning: switching modes on an existing database
+
+[CAUTION]
+====
+Switching a database between `named_graphs=False` and `named_graphs=True` (or vice versa) requires a **full re-import**. You cannot mix the two modes in the same database.
+
+**Why:**
+
+* Default mode requires a *uniqueness constraint* on `:Resource(uri)`.
+  Named-graph mode requires that constraint to be *absent* (duplicate URIs across graphs are valid) and instead needs a plain RANGE index.
+  These two schema objects are incompatible.
+
+* Nodes imported without a `graphUri` property will **not** be returned by graph-filtered queries such as `MATCH (n {graphUri: "..."})`.
+
+**Migration procedure:**
+
+1. Drop the existing uniqueness constraint:
++
+[source,cypher]
+----
+DROP CONSTRAINT n10s_unique_uri IF EXISTS
+----
+
+2. Create the RANGE index:
++
+[source,cypher]
+----
+CREATE INDEX n10s_resource_uri IF NOT EXISTS FOR (r:Resource) ON (r.uri)
+----
+
+3. Delete all existing `:Resource` nodes (they lack `graphUri` and are incompatible with quad semantics).
+
+4. Re-import all data with `named_graphs=True`.
+====

--- a/docs/modules/ROOT/pages/named-graphs.adoc
+++ b/docs/modules/ROOT/pages/named-graphs.adoc
@@ -1,5 +1,7 @@
 = Named Graph / Quad Support
 
+link:https://colab.research.google.com/github/neo4j-labs/rdflib-neo4j/blob/main/notebooks/named_graphs_demo.ipynb[image:https://colab.research.google.com/assets/colab-badge.svg[Open In Colab]]
+
 RDF triples can be grouped into *named graphs*, turning them into *quads*: a four-element tuple of `(subject, predicate, object, graphURI)`.
 Named graphs let you track the provenance of data, partition a dataset by source or version, and query subsets of a larger store.
 

--- a/docs/modules/ROOT/pages/named-graphs.adoc
+++ b/docs/modules/ROOT/pages/named-graphs.adoc
@@ -1,6 +1,6 @@
 = Named Graph / Quad Support
 
-link:https://colab.research.google.com/github/neo4j-labs/rdflib-neo4j/blob/main/notebooks/named_graphs_demo.ipynb[image:https://colab.research.google.com/assets/colab-badge.svg[Open In Colab]]
+link:https://colab.research.google.com/github/neo4j-labs/rdflib-neo4j/blob/main/examples/named_graphs_demo.ipynb[image:https://colab.research.google.com/assets/colab-badge.svg[Open In Colab]]
 
 RDF triples can be grouped into *named graphs*, turning them into *quads*: a four-element tuple of `(subject, predicate, object, graphURI)`.
 Named graphs let you track the provenance of data, partition a dataset by source or version, and query subsets of a larger store.

--- a/examples/named_graphs_demo.ipynb
+++ b/examples/named_graphs_demo.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Named Graph / Quad Support \u2014 End-to-End Demo\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/neo4j-labs/rdflib-neo4j/blob/main/notebooks/named_graphs_demo.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/neo4j-labs/rdflib-neo4j/blob/main/examples/named_graphs_demo.ipynb)\n",
     "\n",
     "This notebook demonstrates `named_graphs=True` in `Neo4jStoreConfig` \u2014 opt-in support\n",
     "for RDF named graphs (quads) that stores each triple alongside the graph URI it came from.\n",

--- a/notebooks/named_graphs_demo.ipynb
+++ b/notebooks/named_graphs_demo.ipynb
@@ -1,0 +1,397 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Named Graph / Quad Support — End-to-End Demo\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/neo4j-labs/rdflib-neo4j/blob/main/notebooks/named_graphs_demo.ipynb)\n",
+    "\n",
+    "This notebook demonstrates `named_graphs=True` in `Neo4jStoreConfig` — opt-in support\n",
+    "for RDF named graphs (quads) that stores each triple alongside the graph URI it came from.\n",
+    "\n",
+    "### The story\n",
+    "\n",
+    "A research organisation publishes data in two separate named graphs:\n",
+    "- **`http://org/graph/people`** — employee directory (persons, departments)\n",
+    "- **`http://org/graph/projects`** — project assignments (who works on what)\n",
+    "\n",
+    "We load both graphs into Neo4j, then query them independently and together.\n",
+    "\n",
+    "### What named graphs do in Neo4j\n",
+    "\n",
+    "Each node and relationship gets a `graphUri` property recording which named graph it\n",
+    "came from. The same URI (e.g. `ex:alice`) written from two different graphs produces\n",
+    "**two separate Neo4j nodes** — one per graph — allowing per-graph isolation and queries.\n",
+    "\n",
+    "> ⚠️ **Switching modes**: changing `named_graphs=True/False` on an existing database\n",
+    "> requires a full re-import. Nodes written without `graphUri` won't be queryable by graph."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 0. Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q rdflib-neo4j neo4j python-dotenv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "from neo4j import GraphDatabase\n",
+    "\n",
+    "load_dotenv()  # reads NEO4J_URI, NEO4J_USERNAME, NEO4J_PASSWORD, NEO4J_DATABASE from .env\n",
+    "\n",
+    "URI      = os.environ[\"NEO4J_URI\"]\n",
+    "USER     = os.environ[\"NEO4J_USERNAME\"]\n",
+    "PASSWORD = os.environ[\"NEO4J_PASSWORD\"]\n",
+    "DATABASE = os.environ.get(\"NEO4J_DATABASE\", \"neo4j\")\n",
+    "\n",
+    "driver = GraphDatabase.driver(URI, auth=(USER, PASSWORD))\n",
+    "driver.verify_connectivity()\n",
+    "print(f\"Connected to {URI} / {DATABASE}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. The Dataset — Two Named Graphs\n",
+    "\n",
+    "We use **TriG** format (Turtle extended with named graph blocks)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TRIG = \"\"\"\n",
+    "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n",
+    "@prefix ex:   <http://example.org/> .\n",
+    "@prefix org:  <http://org/> .\n",
+    "\n",
+    "# Graph 1: employee directory\n",
+    "<http://org/graph/people> {\n",
+    "    ex:alice a foaf:Person ;\n",
+    "        foaf:name \"Alice\" ;\n",
+    "        foaf:age  30 ;\n",
+    "        org:department \"engineering\" .\n",
+    "\n",
+    "    ex:bob a foaf:Person ;\n",
+    "        foaf:name \"Bob\" ;\n",
+    "        foaf:age  25 ;\n",
+    "        org:department \"product\" .\n",
+    "\n",
+    "    ex:carol a foaf:Person ;\n",
+    "        foaf:name \"Carol\" ;\n",
+    "        foaf:age  35 ;\n",
+    "        org:department \"engineering\" .\n",
+    "}\n",
+    "\n",
+    "# Graph 2: project assignments\n",
+    "<http://org/graph/projects> {\n",
+    "    ex:project_a a org:Project ;\n",
+    "        org:name   \"Graph Analytics Platform\" ;\n",
+    "        org:status \"active\" .\n",
+    "\n",
+    "    ex:project_b a org:Project ;\n",
+    "        org:name   \"Data Ingestion Pipeline\" ;\n",
+    "        org:status \"active\" .\n",
+    "\n",
+    "    ex:alice org:worksOn ex:project_a .\n",
+    "    ex:carol org:worksOn ex:project_a .\n",
+    "    ex:bob   org:worksOn ex:project_b .\n",
+    "}\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Load with Named Graph Support\n",
+    "\n",
+    "Use `ConjunctiveGraph` (quad-aware) and set `named_graphs=True` in the config.\n",
+    "Each named graph block in TriG becomes a separate RDF context."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rdflib import ConjunctiveGraph\n",
+    "from rdflib_neo4j import Neo4jStoreConfig, Neo4jStore, HANDLE_VOCAB_URI_STRATEGY\n",
+    "\n",
+    "# Clear previous data + ensure index (named_graphs uses a plain index, not uniqueness)\n",
+    "driver.execute_query(\"MATCH (n:Resource) DETACH DELETE n\", database_=DATABASE)\n",
+    "driver.execute_query(\n",
+    "    \"CREATE INDEX resource_uri IF NOT EXISTS FOR (r:Resource) ON (r.uri)\",\n",
+    "    database_=DATABASE,\n",
+    ")\n",
+    "\n",
+    "auth_data = {\"uri\": URI, \"database\": DATABASE, \"user\": USER, \"pwd\": PASSWORD}\n",
+    "config = Neo4jStoreConfig(\n",
+    "    auth_data=auth_data,\n",
+    "    custom_prefixes={\n",
+    "        \"foaf\": \"http://xmlns.com/foaf/0.1/\",\n",
+    "        \"org\":  \"http://org/\",\n",
+    "    },\n",
+    "    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,\n",
+    "    named_graphs=True,   # ← enable quad support\n",
+    "    batching=False,\n",
+    ")\n",
+    "\n",
+    "cg = ConjunctiveGraph(store=Neo4jStore(config=config))\n",
+    "cg.open(config, create=True)\n",
+    "cg.parse(data=TRIG, format=\"trig\")\n",
+    "cg.close(True)\n",
+    "\n",
+    "# Verify — all Resource nodes with a graphUri property\n",
+    "records, _, _ = driver.execute_query(\n",
+    "    \"MATCH (n:Resource) RETURN n.uri AS uri, n.graphUri AS graph ORDER BY graph, uri\",\n",
+    "    database_=DATABASE,\n",
+    ")\n",
+    "print(f\"{'URI':45}  GRAPH\")\n",
+    "print(\"-\" * 80)\n",
+    "for r in records:\n",
+    "    print(f\"{r['uri']:45}  {r['graph']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Same URI in Two Graphs = Two Nodes\n",
+    "\n",
+    "`ex:alice` appears in BOTH graphs (as a `Person` in people graph, and as a project\n",
+    "assignee in projects graph). With `named_graphs=True` these are **two separate nodes**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "records, _, _ = driver.execute_query(\n",
+    "    \"\"\"\n",
+    "    MATCH (n:Resource {uri: 'http://example.org/alice'})\n",
+    "    RETURN n.graphUri AS graph, labels(n) AS labels, keys(n) AS props\n",
+    "    \"\"\",\n",
+    "    database_=DATABASE,\n",
+    ")\n",
+    "print(f\"Found {len(records)} node(s) for ex:alice:\")\n",
+    "for r in records:\n",
+    "    print(f\"  graph={r['graph']}\")\n",
+    "    print(f\"  labels={r['labels']}\")\n",
+    "    print(f\"  properties={r['props']}\")\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Query a Single Named Graph\n",
+    "\n",
+    "Filter by `graphUri` to scope your query to one graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# People graph only\n",
+    "records, _, _ = driver.execute_query(\n",
+    "    \"\"\"\n",
+    "    MATCH (p:Person {graphUri: 'http://org/graph/people'})\n",
+    "    RETURN p.name AS name, p.age AS age, p.department AS dept\n",
+    "    ORDER BY p.name\n",
+    "    \"\"\",\n",
+    "    database_=DATABASE,\n",
+    ")\n",
+    "print(\"=== People graph ===\")\n",
+    "for r in records:\n",
+    "    print(f\"  {r['name']:8}  age={r['age']}  dept={r['dept']}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Projects graph only\n",
+    "records, _, _ = driver.execute_query(\n",
+    "    \"\"\"\n",
+    "    MATCH (proj:Project {graphUri: 'http://org/graph/projects'})\n",
+    "    RETURN proj.name AS project, proj.status AS status\n",
+    "    ORDER BY project\n",
+    "    \"\"\",\n",
+    "    database_=DATABASE,\n",
+    ")\n",
+    "print(\"=== Projects graph ===\")\n",
+    "for r in records:\n",
+    "    print(f\"  {r['project']:35}  [{r['status']}]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Cross-Graph Query — Join People and Projects\n",
+    "\n",
+    "Even though the two graphs produce separate nodes for the same URIs, we can\n",
+    "join across them by matching on the `uri` property."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "records, _, _ = driver.execute_query(\n",
+    "    \"\"\"\n",
+    "    // Person from the people graph\n",
+    "    MATCH (person:Person {graphUri: 'http://org/graph/people'})\n",
+    "    // Same URI in the projects graph\n",
+    "    MATCH (assignee:Resource {uri: person.uri, graphUri: 'http://org/graph/projects'})\n",
+    "    // Their project assignment\n",
+    "    MATCH (assignee)-[:worksOn]->(proj:Project {graphUri: 'http://org/graph/projects'})\n",
+    "    RETURN person.name AS name, person.department AS dept, proj.name AS project\n",
+    "    ORDER BY name\n",
+    "    \"\"\",\n",
+    "    database_=DATABASE,\n",
+    ")\n",
+    "print(f\"{'Name':8}  {'Dept':12}  Project\")\n",
+    "print(\"-\" * 60)\n",
+    "for r in records:\n",
+    "    print(f\"{r['name']:8}  {r['dept']:12}  {r['project']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Contrast with Default Mode (no named graphs)\n",
+    "\n",
+    "For comparison, import the same data *without* `named_graphs=True`.\n",
+    "Now `ex:alice` maps to a **single node** — no `graphUri`, last-write wins."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Side-by-side comparison (we DON'T commit this — just preview)\n",
+    "from rdflib_neo4j import Neo4jStoreConfig\n",
+    "\n",
+    "config_no_ng = Neo4jStoreConfig(\n",
+    "    custom_prefixes={\n",
+    "        \"foaf\": \"http://xmlns.com/foaf/0.1/\",\n",
+    "        \"org\":  \"http://org/\",\n",
+    "    },\n",
+    "    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,\n",
+    "    named_graphs=False,  # default\n",
+    "    preview=True,        # dry-run: capture queries without executing\n",
+    ")\n",
+    "\n",
+    "from rdflib import Graph\n",
+    "from rdflib_neo4j import Neo4jStore\n",
+    "\n",
+    "g_preview = Graph(store=Neo4jStore(config=config_no_ng))\n",
+    "g_preview.parse(data=TRIG, format=\"trig\")\n",
+    "\n",
+    "print(\"Without named_graphs — first 3 queries:\")\n",
+    "for q, p in config_no_ng.get_preview_results()[:3]:\n",
+    "    print(\"  \", q[:80], \"...\" if len(q) > 80 else \"\")\n",
+    "    if \"graphUri\" in str(p):\n",
+    "        print(\"    ← has graphUri\")\n",
+    "    else:\n",
+    "        print(\"    ← NO graphUri\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. rdflib-level Named Graph Access\n",
+    "\n",
+    "You can also use rdflib's `ConjunctiveGraph.contexts()` and context-scoped queries\n",
+    "to access named graphs through the rdflib API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rdflib import URIRef, ConjunctiveGraph\n",
+    "from rdflib_neo4j import Neo4jStore\n",
+    "\n",
+    "# Re-open in read mode\n",
+    "cg2 = ConjunctiveGraph(store=Neo4jStore(config=config))\n",
+    "cg2.open(config, create=False)\n",
+    "\n",
+    "people_graph = URIRef(\"http://org/graph/people\")\n",
+    "people_ctx = cg2.get_context(people_graph)\n",
+    "\n",
+    "from rdflib import RDF\n",
+    "foaf_Person = URIRef(\"http://xmlns.com/foaf/0.1/Person\")\n",
+    "\n",
+    "print(\"Persons in the people graph (via rdflib API):\")\n",
+    "for s, p, o in people_ctx.triples((None, RDF.type, foaf_Person)):\n",
+    "    print(\" \", s)\n",
+    "\n",
+    "cg2.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "driver.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/named_graphs_demo.ipynb
+++ b/notebooks/named_graphs_demo.ipynb
@@ -4,18 +4,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Named Graph / Quad Support — End-to-End Demo\n",
+    "# Named Graph / Quad Support \u2014 End-to-End Demo\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/neo4j-labs/rdflib-neo4j/blob/main/notebooks/named_graphs_demo.ipynb)\n",
     "\n",
-    "This notebook demonstrates `named_graphs=True` in `Neo4jStoreConfig` — opt-in support\n",
+    "This notebook demonstrates `named_graphs=True` in `Neo4jStoreConfig` \u2014 opt-in support\n",
     "for RDF named graphs (quads) that stores each triple alongside the graph URI it came from.\n",
     "\n",
     "### The story\n",
     "\n",
     "A research organisation publishes data in two separate named graphs:\n",
-    "- **`http://org/graph/people`** — employee directory (persons, departments)\n",
-    "- **`http://org/graph/projects`** — project assignments (who works on what)\n",
+    "- **`http://org/graph/people`** \u2014 employee directory (persons, departments)\n",
+    "- **`http://org/graph/projects`** \u2014 project assignments (who works on what)\n",
     "\n",
     "We load both graphs into Neo4j, then query them independently and together.\n",
     "\n",
@@ -23,9 +23,9 @@
     "\n",
     "Each node and relationship gets a `graphUri` property recording which named graph it\n",
     "came from. The same URI (e.g. `ex:alice`) written from two different graphs produces\n",
-    "**two separate Neo4j nodes** — one per graph — allowing per-graph isolation and queries.\n",
+    "**two separate Neo4j nodes** \u2014 one per graph \u2014 allowing per-graph isolation and queries.\n",
     "\n",
-    "> ⚠️ **Switching modes**: changing `named_graphs=True/False` on an existing database\n",
+    "> \u26a0\ufe0f **Switching modes**: changing `named_graphs=True/False` on an existing database\n",
     "> requires a full re-import. Nodes written without `graphUri` won't be queryable by graph."
    ]
   },
@@ -71,7 +71,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1. The Dataset — Two Named Graphs\n",
+    "## 1. The Dataset \u2014 Two Named Graphs\n",
     "\n",
     "We use **TriG** format (Turtle extended with named graph blocks)."
    ]
@@ -138,42 +138,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rdflib import ConjunctiveGraph\n",
-    "from rdflib_neo4j import Neo4jStoreConfig, Neo4jStore, HANDLE_VOCAB_URI_STRATEGY\n",
-    "\n",
-    "# Clear previous data + ensure index (named_graphs uses a plain index, not uniqueness)\n",
-    "driver.execute_query(\"MATCH (n:Resource) DETACH DELETE n\", database_=DATABASE)\n",
-    "driver.execute_query(\n",
-    "    \"CREATE INDEX resource_uri IF NOT EXISTS FOR (r:Resource) ON (r.uri)\",\n",
-    "    database_=DATABASE,\n",
-    ")\n",
-    "\n",
-    "auth_data = {\"uri\": URI, \"database\": DATABASE, \"user\": USER, \"pwd\": PASSWORD}\n",
-    "config = Neo4jStoreConfig(\n",
-    "    auth_data=auth_data,\n",
-    "    custom_prefixes={\n",
-    "        \"foaf\": \"http://xmlns.com/foaf/0.1/\",\n",
-    "        \"org\":  \"http://org/\",\n",
-    "    },\n",
-    "    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,\n",
-    "    named_graphs=True,   # ← enable quad support\n",
-    "    batching=False,\n",
-    ")\n",
-    "\n",
-    "cg = ConjunctiveGraph(store=Neo4jStore(config=config))\n",
-    "cg.open(config, create=True)\n",
-    "cg.parse(data=TRIG, format=\"trig\")\n",
-    "cg.close(True)\n",
-    "\n",
-    "# Verify — all Resource nodes with a graphUri property\n",
-    "records, _, _ = driver.execute_query(\n",
-    "    \"MATCH (n:Resource) RETURN n.uri AS uri, n.graphUri AS graph ORDER BY graph, uri\",\n",
-    "    database_=DATABASE,\n",
-    ")\n",
-    "print(f\"{'URI':45}  GRAPH\")\n",
-    "print(\"-\" * 80)\n",
-    "for r in records:\n",
-    "    print(f\"{r['uri']:45}  {r['graph']}\")"
+    "from rdflib import ConjunctiveGraph\nfrom rdflib_neo4j import Neo4jStoreConfig, Neo4jStore, HANDLE_VOCAB_URI_STRATEGY\n\n# Clear previous data (index is created by cg.open(config, create=True) below)\ndriver.execute_query(\"MATCH (n:Resource) DETACH DELETE n\", database_=DATABASE)\nauth_data = {\"uri\": URI, \"database\": DATABASE, \"user\": USER, \"pwd\": PASSWORD}\nconfig = Neo4jStoreConfig(\n    auth_data=auth_data,\n    custom_prefixes={\n        \"foaf\": \"http://xmlns.com/foaf/0.1/\",\n        \"org\":  \"http://org/\",\n    },\n    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,\n    named_graphs=True,   # \u2190 enable quad support\n    batching=False,\n)\n\ncg = ConjunctiveGraph(store=Neo4jStore(config=config))\ncg.open(config, create=True)\ncg.parse(data=TRIG, format=\"trig\")\ncg.close(True)\n\n# Verify \u2014 all Resource nodes with a graphUri property\nrecords, _, _ = driver.execute_query(\n    \"MATCH (n:Resource) RETURN n.uri AS uri, n.graphUri AS graph ORDER BY graph, uri\",\n    database_=DATABASE,\n)\nprint(f\"{'URI':45}  GRAPH\")\nprint(\"-\" * 80)\nfor r in records:\n    print(f\"{r['uri']:45}  {r['graph']}\")"
    ]
   },
   {
@@ -260,7 +225,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 5. Cross-Graph Query — Join People and Projects\n",
+    "## 5. Cross-Graph Query \u2014 Join People and Projects\n",
     "\n",
     "Even though the two graphs produce separate nodes for the same URIs, we can\n",
     "join across them by matching on the `uri` property."
@@ -298,7 +263,7 @@
     "## 6. Contrast with Default Mode (no named graphs)\n",
     "\n",
     "For comparison, import the same data *without* `named_graphs=True`.\n",
-    "Now `ex:alice` maps to a **single node** — no `graphUri`, last-write wins."
+    "Now `ex:alice` maps to a **single node** \u2014 no `graphUri`, last-write wins."
    ]
   },
   {
@@ -307,7 +272,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Side-by-side comparison (we DON'T commit this — just preview)\n",
+    "# Side-by-side comparison (we DON'T commit this \u2014 just preview)\n",
     "from rdflib_neo4j import Neo4jStoreConfig\n",
     "\n",
     "config_no_ng = Neo4jStoreConfig(\n",
@@ -326,13 +291,13 @@
     "g_preview = Graph(store=Neo4jStore(config=config_no_ng))\n",
     "g_preview.parse(data=TRIG, format=\"trig\")\n",
     "\n",
-    "print(\"Without named_graphs — first 3 queries:\")\n",
+    "print(\"Without named_graphs \u2014 first 3 queries:\")\n",
     "for q, p in config_no_ng.get_preview_results()[:3]:\n",
     "    print(\"  \", q[:80], \"...\" if len(q) > 80 else \"\")\n",
     "    if \"graphUri\" in str(p):\n",
-    "        print(\"    ← has graphUri\")\n",
+    "        print(\"    \u2190 has graphUri\")\n",
     "    else:\n",
-    "        print(\"    ← NO graphUri\")"
+    "        print(\"    \u2190 NO graphUri\")"
    ]
   },
   {

--- a/rdflib_neo4j/Neo4jStore.py
+++ b/rdflib_neo4j/Neo4jStore.py
@@ -32,6 +32,10 @@ class Neo4jStore(Store):
         elif config.auth_data:
             raise Exception("Either initialize the store with credentials or driver. You cannot do both.")
 
+        # Set named_graphs before super().__init__() because rdflib's Store.__init__
+        # calls self.open() which in turn calls __constraint_check which reads this attr.
+        self.named_graphs = config.named_graphs
+
         super(Neo4jStore, self).__init__(config.get_config_dict())
 
         self.batching = config.batching
@@ -91,16 +95,26 @@ class Neo4jStore(Store):
 
         Args:
             triple: The triple to add.
-            context: The context of the triple (default: None).
+            context: The context of the triple (default: None).  When
+                ``named_graphs=True`` in the store config, ``context`` is
+                expected to be an rdflib ``Graph`` whose ``.identifier``
+                attribute is a ``URIRef`` or ``BNode`` naming the graph.
             quoted (bool): Flag indicating whether the triple is quoted (default: False).
         """
         assert self.is_open(), "The Store must be open."
         assert context != self, "Can not add triple directly to store"
 
+        # Resolve named-graph URI when the feature is enabled
+        graph_uri = None
+        if self.named_graphs and context is not None:
+            identifier = getattr(context, "identifier", None)
+            if identifier is not None:
+                graph_uri = str(identifier)
+
         # Unpacking the triple
         (subject, predicate, object) = triple
 
-        self.__check_current_subject(subject=subject)
+        self.__check_current_subject(subject=subject, graph_uri=graph_uri)
         self.current_subject.parse_triple(triple=triple, mappings=self.mappings)
         self.total_triples += 1
 
@@ -180,19 +194,32 @@ class Neo4jStore(Store):
 
     def __constraint_check(self, create):
         """
-        Checks the existence of a uniqueness constraint on the `Resource` node with the `uri` property.
+        Checks (and optionally creates) the required schema object on :Resource.
+
+        * **Default mode** (``named_graphs=False``): requires a uniqueness constraint
+          on ``:Resource(uri)`` — the same one used by n10s triple import.
+
+        * **Named-graph mode** (``named_graphs=True``): requires only a plain index on
+          ``:Resource(uri)`` because the same URI can exist in multiple graphs as
+          separate nodes.  A uniqueness constraint would reject duplicate URIs across
+          graphs, so it must not be present.
 
         Args:
-            create (bool): Flag indicating whether to create the constraint if not found.
-
+            create (bool): Flag indicating whether to create the missing schema object.
         """
-        # Test connectivity to backend and check that constraint on :Resource(uri) is present
+        if self.named_graphs:
+            self.__index_check(create)
+        else:
+            self.__uniqueness_constraint_check(create)
+
+    def __uniqueness_constraint_check(self, create):
+        """Check / create the uniqueness constraint on :Resource(uri)."""
         constraint_check = """
-           SHOW CONSTRAINTS YIELD * 
-           WHERE type = "UNIQUENESS" 
-               AND entityType = "NODE" 
-               AND labelsOrTypes = ["Resource"] 
-               AND properties = ["uri"] 
+           SHOW CONSTRAINTS YIELD *
+           WHERE type = "UNIQUENESS"
+               AND entityType = "NODE"
+               AND labelsOrTypes = ["Resource"]
+               AND properties = ["uri"]
            RETURN COUNT(*) = 1 AS constraint_found
            """
         result = self.session.run(constraint_check)
@@ -200,7 +227,6 @@ class Neo4jStore(Store):
 
         if not constraint_found and create:
             try:
-                # Create the uniqueness constraint
                 create_constraint = """
                    CREATE CONSTRAINT n10s_unique_uri IF NOT EXISTS FOR (r:Resource) REQUIRE r.uri IS UNIQUE
                    """
@@ -210,10 +236,38 @@ class Neo4jStore(Store):
                 print("Error: Unable to create the uniqueness constraint. Make sure you have the necessary privileges.")
                 print("Exception: ", e)
         else:
-            print(f"""Uniqueness constraint on :Resource(uri) {"" if constraint_found else "not "}found. 
-               {"" if constraint_found else "Run the following command on the Neo4j DB to create the constraint: "
-                                            "CREATE CONSTRAINT n10s_unique_uri FOR (r:Resource) REQUIRE r.uri IS UNIQUE. Or provide create=True to create it."} 
-                """)
+            print(f"""Uniqueness constraint on :Resource(uri) {"" if constraint_found else "not "}found. \
+{"" if constraint_found else "Run: CREATE CONSTRAINT n10s_unique_uri FOR (r:Resource) REQUIRE r.uri IS UNIQUE, or pass create=True."}\
+""")
+
+    def __index_check(self, create):
+        """Check / create a plain index on :Resource(uri) (required for named-graph mode)."""
+        index_check = """
+           SHOW INDEXES YIELD *
+           WHERE type = "RANGE"
+               AND entityType = "NODE"
+               AND labelsOrTypes = ["Resource"]
+               AND properties = ["uri"]
+           RETURN COUNT(*) >= 1 AS index_found
+           """
+        result = self.session.run(index_check)
+        index_found = next((True for x in result if x["index_found"]), False)
+
+        if not index_found and create:
+            try:
+                self.session.run(
+                    "CREATE INDEX n10s_resource_uri IF NOT EXISTS FOR (r:Resource) ON (r.uri)"
+                )
+                print("Index on :Resource(uri) is created (named-graph mode).")
+            except Exception as e:
+                print("Error: Unable to create the index on :Resource(uri).")
+                print("Exception: ", e)
+        else:
+            print(
+                f"Index on :Resource(uri) {'found' if index_found else 'not found'} "
+                f"(named-graph mode)."
+                + ("" if index_found else " Run: CREATE INDEX n10s_resource_uri FOR (r:Resource) ON (r.uri), or pass create=True.")
+            )
 
     def __store_current_subject_props(self):
         """
@@ -222,10 +276,17 @@ class Neo4jStore(Store):
         This function adds the properties of the current subject to the node buffer for later insertion into the Neo4j database.
         """
         label_key = self.current_subject.extract_label_key()
+        # When named_graphs is active, each (labels, graphUri) combination needs its
+        # own NodeQueryComposer so that the MERGE key is consistent within a batch.
+        if self.named_graphs and self.current_subject.graph_uri is not None:
+            label_key = f"{label_key}|{self.current_subject.graph_uri}"
         if label_key not in self.node_buffer:
-            self.node_buffer[label_key] = NodeQueryComposer(labels=self.current_subject.labels,
-                                                            handle_multival_strategy=self.handle_multival_strategy,
-                                                            multival_props_predicates=self.multival_props_predicates)
+            self.node_buffer[label_key] = NodeQueryComposer(
+                labels=self.current_subject.labels,
+                handle_multival_strategy=self.handle_multival_strategy,
+                multival_props_predicates=self.multival_props_predicates,
+                graph_uri_aware=self.named_graphs,
+            )
 
         self.node_buffer[label_key].add_props(self.current_subject.extract_props_names())
         self.node_buffer[label_key].add_props(self.current_subject.extract_props_names(multi=True), multi=True)
@@ -241,11 +302,19 @@ class Neo4jStore(Store):
         """
         rel_types_and_relationships = self.current_subject.extract_rels()
         if self.current_subject.extract_rels():
+            graph_uri = self.current_subject.graph_uri if self.named_graphs else None
             for rel_type in rel_types_and_relationships:
                 if rel_type not in self.rel_buffer:
-                    self.rel_buffer[rel_type] = RelationshipQueryComposer(rel_type)
+                    self.rel_buffer[rel_type] = RelationshipQueryComposer(
+                        rel_type,
+                        graph_uri_aware=self.named_graphs,
+                    )
                 for to_node in rel_types_and_relationships[rel_type]:
-                    self.rel_buffer[rel_type].add_query_param(from_node=self.current_subject.uri, to_node=to_node)
+                    self.rel_buffer[rel_type].add_query_param(
+                        from_node=self.current_subject.uri,
+                        to_node=to_node,
+                        graph_uri=graph_uri,
+                    )
                     self.rel_buffer_size += 1
 
     def __store_current_subject(self):
@@ -257,7 +326,7 @@ class Neo4jStore(Store):
         self.__store_current_subject_props()
         self.__store_current_subject_rels()
 
-    def __create_current_subject(self, subject):
+    def __create_current_subject(self, subject, graph_uri=None):
         return Neo4jTriple(
             uri=subject,
             prefixes={value: key for key, value in self.config.get_prefixes().items()},
@@ -268,9 +337,10 @@ class Neo4jStore(Store):
             keep_lang_tag=self.config.keep_lang_tag,
             keep_custom_data_types=self.config.keep_custom_data_types,
             language_filter=self.config.language_filter,
+            graph_uri=graph_uri,
         )
 
-    def __check_current_subject(self, subject):
+    def __check_current_subject(self, subject, graph_uri=None):
         """
         Checks the current subject and stores the previous subject if it has changed.
 
@@ -279,20 +349,26 @@ class Neo4jStore(Store):
 
         Args:
             subject: The subject to check.
+            graph_uri: Optional named-graph URI string for the current triple.
         """
         if self.current_subject is None:
-            self.current_subject = self.__create_current_subject(subject)
+            self.current_subject = self.__create_current_subject(subject, graph_uri)
         else:
-            if self.current_subject.uri != subject:
+            # A new subject or a new graph context forces a flush of the previous subject
+            if self.current_subject.uri != subject or self.current_subject.graph_uri != graph_uri:
                 self.__store_current_subject()
-                self.current_subject = self.__create_current_subject(subject)
+                self.current_subject = self.__create_current_subject(subject, graph_uri)
 
-    def triples(self, triple):
+    def triples(self, triple, context=None):
         """
         Yield triples matching the pattern. Any component may be None (wildcard).
 
         Args:
             triple: A (subject, predicate, object) tuple; any element may be None.
+            context: Optional graph context.  When ``named_graphs=True`` in the store
+                config, passing a graph object here restricts results to triples that
+                were stored under the named graph identified by
+                ``context.identifier``.
 
         Yields:
             ((subject, predicate, object), self) tuples, matching the rdflib
@@ -303,6 +379,14 @@ class Neo4jStore(Store):
         from rdflib_neo4j.expander import expand_uri, neo4j_value_to_literal
 
         (s, p, o) = triple
+
+        # Resolve named-graph filter when the feature is enabled
+        graph_uri = None
+        if self.named_graphs and context is not None:
+            identifier = getattr(context, "identifier", None)
+            if identifier is not None:
+                graph_uri = str(identifier)
+
         prefix_map = {name: str(ns) for name, ns in self.config.get_prefixes().items()}
 
         # Yield property and label triples from a node record
@@ -315,9 +399,9 @@ class Neo4jStore(Store):
             props = record["props"]
             labels = record["extra_labels"]
 
-            # Property triples
+            # Property triples (skip internal Neo4j bookkeeping keys)
             for prop_key, prop_val in props.items():
-                if prop_key == "uri":
+                if prop_key in ("uri", "graphUri"):
                     continue
                 predicate = expand_uri(prop_key, prefix_map)
                 if p is not None and predicate != p:
@@ -355,27 +439,47 @@ class Neo4jStore(Store):
         if s is not None:
             # Subject known — query specific node
             s_uri = f"bnode://{s}" if isinstance(s, BNode) else str(s)
+            run_kwargs = {"uri": s_uri}
+            if graph_uri is not None:
+                run_kwargs["graphUri"] = graph_uri
             node_result = self.session.run(
-                ExportQueryComposer.node_by_uri_query(), uri=s_uri
+                ExportQueryComposer.node_by_uri_query(graph_uri=graph_uri),
+                **run_kwargs,
             )
             for record in node_result:
                 yield from _node_triples(record)
             # Only fetch relationships when predicate is not rdf:type and object
             # is not a Literal (relationships link Resource nodes only)
             if p != RDF.type and not isinstance(o, Literal):
+                rel_kwargs = {"uri": s_uri}
+                if graph_uri is not None:
+                    rel_kwargs["graphUri"] = graph_uri
                 rel_result = self.session.run(
-                    ExportQueryComposer.relationships_from_uri_query(), uri=s_uri
+                    ExportQueryComposer.relationships_from_uri_query(graph_uri=graph_uri),
+                    **rel_kwargs,
                 )
                 for record in rel_result:
                     yield from _rel_triples(record)
         else:
             # Subject wildcard — scan all nodes
-            node_result = self.session.run(ExportQueryComposer.all_nodes_query())
+            node_kwargs = {}
+            if graph_uri is not None:
+                node_kwargs["graphUri"] = graph_uri
+            node_result = self.session.run(
+                ExportQueryComposer.all_nodes_query(graph_uri=graph_uri),
+                **node_kwargs,
+            )
             for record in node_result:
                 yield from _node_triples(record)
             # Fetch relationships unless we know only Literal objects are wanted
             if not isinstance(o, Literal):
-                rel_result = self.session.run(ExportQueryComposer.all_relationships_query())
+                rel_kwargs = {}
+                if graph_uri is not None:
+                    rel_kwargs["graphUri"] = graph_uri
+                rel_result = self.session.run(
+                    ExportQueryComposer.all_relationships_query(graph_uri=graph_uri),
+                    **rel_kwargs,
+                )
                 for record in rel_result:
                     yield from _rel_triples(record)
 

--- a/rdflib_neo4j/Neo4jTriple.py
+++ b/rdflib_neo4j/Neo4jTriple.py
@@ -27,7 +27,8 @@ class Neo4jTriple:
                  prefixes: Dict[str, str],
                  keep_lang_tag: bool = False,
                  keep_custom_data_types: bool = False,
-                 language_filter: Optional[str] = None):
+                 language_filter: Optional[str] = None,
+                 graph_uri: Optional[str] = None):
         """
         Constructor for Neo4jTriple.
 
@@ -37,6 +38,9 @@ class Neo4jTriple:
             handle_multival_strategy: The strategy to handle multiple values.
             multival_props_names: A list containing URIs to be treated as multivalued.
             prefixes: A dictionary of namespace prefixes used for vocabulary URI handling.
+            graph_uri: Optional named graph URI string; when set, stored as the ``graphUri``
+                property on the Neo4j node so that the same resource URI in different named
+                graphs is kept as a distinct node (n10s quad semantics).
         """
         self.uri = uri
         self.labels = set()
@@ -50,6 +54,7 @@ class Neo4jTriple:
         self.keep_lang_tag = keep_lang_tag
         self.keep_custom_data_types = keep_custom_data_types
         self.language_filter = language_filter
+        self.graph_uri = graph_uri
 
     def add_label(self, label: str):
         """
@@ -108,11 +113,15 @@ class Neo4jTriple:
         Extracts the properties from the `props` dictionary of the Neo4jTriple object.
 
         Returns:
-            dict: The extracted properties.
+            dict: The extracted properties. When ``graph_uri`` is set on this triple,
+            the dict also contains a ``graphUri`` key so that the Cypher query can
+            MERGE on both ``uri`` and ``graphUri``.
         """
         res = {key: value for key, value in self.props.items()}
         res["uri"] = self.uri
         res.update(self.multi_props)
+        if self.graph_uri is not None:
+            res["graphUri"] = self.graph_uri
         return res
 
     def extract_props_names(self, multi=False):

--- a/rdflib_neo4j/config/Neo4jStoreConfig.py
+++ b/rdflib_neo4j/config/Neo4jStoreConfig.py
@@ -27,6 +27,11 @@ class Neo4jStoreConfig:
     - handle_multival_strategy: The strategy to handle multivalued properties (default: HANDLE_MULTIVAL_STRATEGY.OVERWRITE).
 
     - multival_props_names: A list of tuples containing the prefix and property names to be treated as multivalued in the form (prefix, property_name)
+
+    - named_graphs: When True, enable named graph (quad) support. Each triple is stored with a ``graphUri``
+      property derived from the RDF context identifier. The same resource URI in different named graphs
+      becomes separate Neo4j nodes, matching n10s quad-import semantics. The store then requires a plain
+      index on ``:Resource(uri)`` instead of a uniqueness constraint. Default: False.
     """
 
     def __init__(
@@ -42,6 +47,7 @@ class Neo4jStoreConfig:
             keep_lang_tag: bool = False,
             keep_custom_data_types: bool = False,
             language_filter: Optional[str] = None,
+            named_graphs: bool = False,
     ):
         self.default_prefixes = DEFAULT_PREFIXES
         self.auth_data = auth_data
@@ -59,6 +65,7 @@ class Neo4jStoreConfig:
         self.keep_lang_tag = keep_lang_tag
         self.keep_custom_data_types = keep_custom_data_types
         self.language_filter = language_filter
+        self.named_graphs = named_graphs
 
     def set_handle_vocab_uri_strategy(self, val: HANDLE_VOCAB_URI_STRATEGY):
         """

--- a/rdflib_neo4j/config/const.py
+++ b/rdflib_neo4j/config/const.py
@@ -57,7 +57,7 @@ class CypherMultipleTypesMultiValueException(Exception):
         super().__init__()
 
     def __str__(self):
-        return f"""Values of a multivalued property must have the same datatype."""
+        return """Values of a multivalued property must have the same datatype."""
 
 NEO4J_DRIVER_MULTIPLE_TYPE_ERROR_MESSAGE = """{code: Neo.ClientError.Statement.TypeError} {message: Neo4j only supports a subset of Cypher types for storage as singleton or array properties. Please refer to section cypher/syntax/values of the manual for more details.}"""
 NEO4J_DRIVER_DICT_MESSAGE = {NEO4J_DRIVER_MULTIPLE_TYPE_ERROR_MESSAGE: CypherMultipleTypesMultiValueException}

--- a/rdflib_neo4j/query_composers/ExportQueryComposer.py
+++ b/rdflib_neo4j/query_composers/ExportQueryComposer.py
@@ -2,8 +2,20 @@ class ExportQueryComposer:
     """Generates Cypher queries for reading RDF triples from Neo4j."""
 
     @staticmethod
-    def all_nodes_query() -> str:
-        """Fetch all Resource nodes with their props and labels."""
+    def all_nodes_query(graph_uri: str = None) -> str:
+        """Fetch all Resource nodes with their props and labels.
+
+        Args:
+            graph_uri: When provided, restrict results to nodes whose ``graphUri``
+                property matches (named-graph filter).
+        """
+        if graph_uri is not None:
+            return (
+                "MATCH (n:Resource {graphUri: $graphUri}) "
+                "RETURN n.uri AS uri, "
+                "       [l IN labels(n) WHERE l <> 'Resource'] AS extra_labels, "
+                "       properties(n) AS props"
+            )
         return (
             "MATCH (n:Resource) "
             "RETURN n.uri AS uri, "
@@ -12,8 +24,19 @@ class ExportQueryComposer:
         )
 
     @staticmethod
-    def node_by_uri_query() -> str:
-        """Fetch a specific Resource node."""
+    def node_by_uri_query(graph_uri: str = None) -> str:
+        """Fetch a specific Resource node.
+
+        Args:
+            graph_uri: When provided, also filter by ``graphUri`` property.
+        """
+        if graph_uri is not None:
+            return (
+                "MATCH (n:Resource {uri: $uri, graphUri: $graphUri}) "
+                "RETURN n.uri AS uri, "
+                "       [l IN labels(n) WHERE l <> 'Resource'] AS extra_labels, "
+                "       properties(n) AS props"
+            )
         return (
             "MATCH (n:Resource {uri: $uri}) "
             "RETURN n.uri AS uri, "
@@ -22,16 +45,37 @@ class ExportQueryComposer:
         )
 
     @staticmethod
-    def all_relationships_query() -> str:
-        """Fetch all relationships between Resource nodes."""
+    def all_relationships_query(graph_uri: str = None) -> str:
+        """Fetch all relationships between Resource nodes.
+
+        Args:
+            graph_uri: When provided, restrict to relationships whose ``graphUri``
+                property matches.
+        """
+        if graph_uri is not None:
+            return (
+                "MATCH (a:Resource)-[r]->(b:Resource) "
+                "WHERE r.graphUri = $graphUri "
+                "RETURN a.uri AS from_uri, type(r) AS rel_type, b.uri AS to_uri"
+            )
         return (
             "MATCH (a:Resource)-[r]->(b:Resource) "
             "RETURN a.uri AS from_uri, type(r) AS rel_type, b.uri AS to_uri"
         )
 
     @staticmethod
-    def relationships_from_uri_query() -> str:
-        """Fetch relationships from a specific subject."""
+    def relationships_from_uri_query(graph_uri: str = None) -> str:
+        """Fetch relationships from a specific subject.
+
+        Args:
+            graph_uri: When provided, also filter by relationship ``graphUri`` property.
+        """
+        if graph_uri is not None:
+            return (
+                "MATCH (a:Resource {uri: $uri})-[r]->(b:Resource) "
+                "WHERE r.graphUri = $graphUri "
+                "RETURN a.uri AS from_uri, type(r) AS rel_type, b.uri AS to_uri"
+            )
         return (
             "MATCH (a:Resource {uri: $uri})-[r]->(b:Resource) "
             "RETURN a.uri AS from_uri, type(r) AS rel_type, b.uri AS to_uri"

--- a/rdflib_neo4j/query_composers/NodeQueryComposer.py
+++ b/rdflib_neo4j/query_composers/NodeQueryComposer.py
@@ -17,12 +17,16 @@ class NodeQueryComposer:
     props: Set[str] = set()
     query_params: List[Dict]
 
-    def __init__(self, labels, handle_multival_strategy, multival_props_predicates):
+    def __init__(self, labels, handle_multival_strategy, multival_props_predicates,
+                 graph_uri_aware: bool = False):
         """
         Initializes a NodeQueryComposer object.
 
         Args:
             labels: The labels to assign to the nodes.
+            graph_uri_aware: When True the MERGE clause matches on both ``uri`` and
+                ``graphUri``, so the same resource URI in different named graphs
+                produces separate Neo4j nodes (n10s quad semantics).
         """
         self.labels = labels
         self.props = set()
@@ -30,6 +34,7 @@ class NodeQueryComposer:
         self.query_params = []
         self.handle_multival_strategy = handle_multival_strategy
         self.multival_props_predicates = multival_props_predicates
+        self.graph_uri_aware = graph_uri_aware
 
     def add_props(self, props, multi=False):
         """
@@ -57,11 +62,21 @@ class NodeQueryComposer:
         """
         Writes the Neo4j query for creating nodes with labels and properties.
 
+        When ``graph_uri_aware`` is True the MERGE matches on both ``uri`` and
+        ``graphUri`` so that the same resource URI in different named graphs is
+        stored as separate nodes, mirroring n10s quad-import semantics.
+
         Returns:
             str: The Neo4j query.
         """
-
-        q = f''' UNWIND $params as param MERGE (n:Resource{{ uri : param["uri"] }}) '''
+        if self.graph_uri_aware:
+            q = (
+                ' UNWIND $params as param'
+                ' MERGE (n:Resource{ uri : param["uri"], graphUri : param["graphUri"] })'
+                ' '
+            )
+        else:
+            q = ' UNWIND $params as param MERGE (n:Resource{ uri : param["uri"] }) '
         if self.labels:
             q += f'''SET {', '.join([f"""n:`{label}`""" for label in self.labels])} '''
         if self.props or self.multi_props:

--- a/rdflib_neo4j/query_composers/RelationshipQueryComposer.py
+++ b/rdflib_neo4j/query_composers/RelationshipQueryComposer.py
@@ -6,16 +6,21 @@ class RelationshipQueryComposer:
     props: Set[str] = set()
     query_params: List[Dict]
 
-    def __init__(self, rel_type):
+    def __init__(self, rel_type, graph_uri_aware: bool = False):
         """
         Initializes a RelationshipQueryComposer object.
 
         Args:
             rel_type (str): The type of the relationship.
+            graph_uri_aware: When True the MERGE for both endpoint nodes matches on
+                both ``uri`` and ``graphUri``.  The relationship itself also receives a
+                ``graphUri`` property so that it can be filtered by named graph on the
+                read path.
         """
         self.rel_type = rel_type
         self.props = set()
         self.query_params = []
+        self.graph_uri_aware = graph_uri_aware
 
     def add_props(self, props):
         """
@@ -25,9 +30,9 @@ class RelationshipQueryComposer:
             props: The properties to add.
         """
         self.props.update(props)
-        raise NotImplemented("TO WORK ON THIS, WE NEED TEST DATA")
+        raise NotImplementedError("TO WORK ON THIS, WE NEED TEST DATA")
 
-    def add_query_param(self, from_node, to_node):
+    def add_query_param(self, from_node, to_node, graph_uri=None):
         """
         Adds a query parameter consisting of 'from' (The URI of the node at the start of the relationship)
             and 'to' (The URI of the node at the end of the relationship).
@@ -35,23 +40,42 @@ class RelationshipQueryComposer:
         Args:
             from_node: The 'from' node (The URI of the node at the start of the relationship).
             to_node: The 'to' node (The URI of the node at the end of the relationship).
+            graph_uri: Optional named-graph URI string; stored on the relationship as
+                ``graphUri`` when ``graph_uri_aware`` is True.
         """
-        self.query_params.append({"from": from_node, "to": to_node})
+        param = {"from": from_node, "to": to_node}
+        if graph_uri is not None:
+            param["graphUri"] = graph_uri
+        self.query_params.append(param)
 
     def write_query(self):
         """
         Writes the Neo4j query for creating relationships with properties.
 
+        When ``graph_uri_aware`` is True, each endpoint node is looked up (or
+        created) by both ``uri`` and ``graphUri``, and the relationship receives a
+        ``graphUri`` property so the read path can filter by named graph.
+
         Returns:
             str: The Neo4j query.
         """
-        q = f''' UNWIND $params as param 
-                 MERGE (from:Resource{{ uri : param["from"] }}) 
-                 MERGE (to:Resource{{ uri : param["to"] }})
+        if self.graph_uri_aware:
+            q = (
+                ' UNWIND $params as param'
+                ' MERGE (from:Resource{ uri : param["from"], graphUri : param["graphUri"] })'
+                ' MERGE (to:Resource{ uri : param["to"], graphUri : param["graphUri"] })'
+                ' '
+            )
+            q += f' MERGE (from)-[r:`{self.rel_type}`]->(to)'
+            q += ' SET r.graphUri = param["graphUri"]'
+        else:
+            q = ''' UNWIND $params as param
+                 MERGE (from:Resource{ uri : param["from"] })
+                 MERGE (to:Resource{ uri : param["to"] })
              '''
-        q += f''' MERGE (from)-[r:`{self.rel_type}`]->(to)'''
+            q += f''' MERGE (from)-[r:`{self.rel_type}`]->(to)'''
         if self.props:
-            raise NotImplemented
+            raise NotImplementedError
             # q += f'''SET {', '.join([f"""r.`{prop}` = coalesce(param["{prop}"],null)""" for prop in self.props])}'''
         return q
 

--- a/test/unit/test_named_graphs.py
+++ b/test/unit/test_named_graphs.py
@@ -1,0 +1,356 @@
+"""
+Unit tests for the named-graph (quad) feature (#63).
+
+All tests use a mocked Neo4j session — no real database connection needed.
+"""
+from unittest.mock import MagicMock
+
+from rdflib import URIRef, Literal, Graph
+
+from rdflib_neo4j.config.Neo4jStoreConfig import Neo4jStoreConfig
+from rdflib_neo4j.config.const import HANDLE_VOCAB_URI_STRATEGY
+from rdflib_neo4j.Neo4jStore import Neo4jStore
+from rdflib_neo4j.Neo4jTriple import Neo4jTriple
+from rdflib_neo4j.query_composers.NodeQueryComposer import NodeQueryComposer
+from rdflib_neo4j.query_composers.RelationshipQueryComposer import RelationshipQueryComposer
+from rdflib_neo4j.query_composers.ExportQueryComposer import ExportQueryComposer
+
+EX = "http://example.org/"
+G1 = "http://example.org/graphs/g1"
+G2 = "http://example.org/graphs/g2"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_store(named_graphs=False, strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE):
+    """Build a Neo4jStore with a mocked driver/session."""
+    config = Neo4jStoreConfig(
+        auth_data=None,
+        handle_vocab_uri_strategy=strategy,
+        named_graphs=named_graphs,
+    )
+    mock_driver = MagicMock()
+    store = Neo4jStore(config=config, neo4j_driver=mock_driver)
+    store.session = MagicMock()
+    store._Neo4jStore__open = True
+    return store
+
+
+def make_graph(uri_str):
+    """Return an rdflib Graph whose identifier is uri_str."""
+    g = Graph(identifier=URIRef(uri_str))
+    return g
+
+
+def _mock_run(store, *result_sequences):
+    """Configure store.session.run() to return successive mock result objects."""
+    def make_result(rows):
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(return_value=iter(rows))
+        return mock_result
+
+    store.session.run.side_effect = [make_result(rows) for rows in result_sequences]
+
+
+# ---------------------------------------------------------------------------
+# Neo4jStoreConfig — named_graphs flag
+# ---------------------------------------------------------------------------
+
+class TestNeo4jStoreConfigNamedGraphs:
+    def test_default_is_false(self):
+        config = Neo4jStoreConfig(auth_data=None)
+        assert config.named_graphs is False
+
+    def test_can_set_true(self):
+        config = Neo4jStoreConfig(auth_data=None, named_graphs=True)
+        assert config.named_graphs is True
+
+    def test_reflected_in_store(self):
+        store = make_store(named_graphs=True)
+        assert store.named_graphs is True
+
+    def test_default_store_named_graphs_false(self):
+        store = make_store(named_graphs=False)
+        assert store.named_graphs is False
+
+
+# ---------------------------------------------------------------------------
+# Neo4jTriple — graph_uri parameter and extract_params
+# ---------------------------------------------------------------------------
+
+class TestNeo4jTripleGraphUri:
+    def _make_triple(self, graph_uri=None):
+        return Neo4jTriple(
+            uri=URIRef(f"{EX}s"),
+            handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,
+            handle_multival_strategy=MagicMock(),
+            multival_props_names=[],
+            prefixes={},
+            graph_uri=graph_uri,
+        )
+
+    def test_no_graph_uri_not_in_params(self):
+        triple = self._make_triple(graph_uri=None)
+        params = triple.extract_params()
+        assert "graphUri" not in params
+
+    def test_graph_uri_in_params(self):
+        triple = self._make_triple(graph_uri=G1)
+        params = triple.extract_params()
+        assert params["graphUri"] == G1
+
+    def test_graph_uri_preserved_alongside_props(self):
+        triple = self._make_triple(graph_uri=G2)
+        triple.add_prop("name", "Alice")
+        params = triple.extract_params()
+        assert params["graphUri"] == G2
+        assert params["name"] == "Alice"
+
+
+# ---------------------------------------------------------------------------
+# NodeQueryComposer — graph_uri_aware flag
+# ---------------------------------------------------------------------------
+
+class TestNodeQueryComposerGraphUriAware:
+    def test_default_merge_uses_uri_only(self):
+        composer = NodeQueryComposer(
+            labels=set(),
+            handle_multival_strategy=MagicMock(),
+            multival_props_predicates=[],
+        )
+        q = composer.write_query()
+        assert 'graphUri' not in q
+        assert 'param["uri"]' in q
+
+    def test_graph_uri_aware_merge_includes_graphUri(self):
+        composer = NodeQueryComposer(
+            labels=set(),
+            handle_multival_strategy=MagicMock(),
+            multival_props_predicates=[],
+            graph_uri_aware=True,
+        )
+        q = composer.write_query()
+        assert 'graphUri' in q
+        assert 'param["graphUri"]' in q
+        assert 'param["uri"]' in q
+
+    def test_graph_uri_aware_false_by_default(self):
+        composer = NodeQueryComposer(
+            labels=set(),
+            handle_multival_strategy=MagicMock(),
+            multival_props_predicates=[],
+        )
+        assert composer.graph_uri_aware is False
+
+
+# ---------------------------------------------------------------------------
+# RelationshipQueryComposer — graph_uri_aware flag
+# ---------------------------------------------------------------------------
+
+class TestRelationshipQueryComposerGraphUriAware:
+    def test_default_no_graphUri_in_query(self):
+        composer = RelationshipQueryComposer("KNOWS")
+        q = composer.write_query()
+        assert 'graphUri' not in q
+
+    def test_graph_uri_aware_query_includes_graphUri(self):
+        composer = RelationshipQueryComposer("KNOWS", graph_uri_aware=True)
+        q = composer.write_query()
+        assert 'graphUri' in q
+
+    def test_add_query_param_with_graph_uri(self):
+        composer = RelationshipQueryComposer("KNOWS", graph_uri_aware=True)
+        composer.add_query_param(
+            from_node="http://a", to_node="http://b", graph_uri=G1
+        )
+        assert composer.query_params[0]["graphUri"] == G1
+
+    def test_add_query_param_without_graph_uri(self):
+        composer = RelationshipQueryComposer("KNOWS")
+        composer.add_query_param(from_node="http://a", to_node="http://b")
+        assert "graphUri" not in composer.query_params[0]
+
+
+# ---------------------------------------------------------------------------
+# ExportQueryComposer — graph_uri filtering
+# ---------------------------------------------------------------------------
+
+class TestExportQueryComposerGraphUri:
+    def test_all_nodes_no_graph_uri(self):
+        q = ExportQueryComposer.all_nodes_query()
+        assert "graphUri" not in q
+
+    def test_all_nodes_with_graph_uri(self):
+        q = ExportQueryComposer.all_nodes_query(graph_uri=G1)
+        assert "graphUri" in q
+        assert "$graphUri" in q
+
+    def test_node_by_uri_no_graph_uri(self):
+        q = ExportQueryComposer.node_by_uri_query()
+        assert "graphUri" not in q
+
+    def test_node_by_uri_with_graph_uri(self):
+        q = ExportQueryComposer.node_by_uri_query(graph_uri=G1)
+        assert "graphUri" in q
+
+    def test_all_relationships_no_graph_uri(self):
+        q = ExportQueryComposer.all_relationships_query()
+        assert "graphUri" not in q
+
+    def test_all_relationships_with_graph_uri(self):
+        q = ExportQueryComposer.all_relationships_query(graph_uri=G1)
+        assert "graphUri" in q
+
+    def test_relationships_from_uri_no_graph_uri(self):
+        q = ExportQueryComposer.relationships_from_uri_query()
+        assert "graphUri" not in q
+
+    def test_relationships_from_uri_with_graph_uri(self):
+        q = ExportQueryComposer.relationships_from_uri_query(graph_uri=G1)
+        assert "graphUri" in q
+
+
+# ---------------------------------------------------------------------------
+# Neo4jStore.add() — graph_uri propagation
+# ---------------------------------------------------------------------------
+
+class TestNeo4jStoreAddNamedGraphs:
+    def test_add_without_named_graphs_ignores_context(self):
+        """When named_graphs=False, context is ignored (existing behaviour)."""
+        store = make_store(named_graphs=False)
+        store.batching = False
+        store.session.run = MagicMock()
+
+        ctx = make_graph(G1)
+        store.add(
+            (URIRef(f"{EX}s"), URIRef(f"{EX}p"), Literal("v")),
+            context=ctx,
+        )
+        store.commit()
+
+        # The query params must NOT contain graphUri
+        all_params = []
+        for c in store.session.run.call_args_list:
+            params_arg = c[1].get("params") or (c[0][1] if len(c[0]) > 1 else None)
+            if isinstance(params_arg, list):
+                all_params.extend(params_arg)
+        for param in all_params:
+            assert "graphUri" not in param
+
+    def test_add_with_named_graphs_stores_graph_uri(self):
+        """When named_graphs=True, graphUri is included in node params."""
+        store = make_store(named_graphs=True)
+        store.batching = False
+        store.session.run = MagicMock()
+
+        ctx = make_graph(G1)
+        store.add(
+            (URIRef(f"{EX}s"), URIRef(f"{EX}p"), Literal("v")),
+            context=ctx,
+        )
+        store.commit()
+
+        # Find the UNWIND call and check its params
+        graph_uri_found = False
+        for c in store.session.run.call_args_list:
+            params_arg = c[1].get("params")
+            if isinstance(params_arg, list):
+                for row in params_arg:
+                    if row.get("graphUri") == G1:
+                        graph_uri_found = True
+        assert graph_uri_found, "graphUri not found in any node query param"
+
+    def test_add_without_context_in_named_graphs_mode(self):
+        """When named_graphs=True but no context provided, graphUri is absent."""
+        store = make_store(named_graphs=True)
+        store.batching = False
+        store.session.run = MagicMock()
+
+        store.add(
+            (URIRef(f"{EX}s"), URIRef(f"{EX}p"), Literal("v")),
+            context=None,
+        )
+        store.commit()
+
+        for c in store.session.run.call_args_list:
+            params_arg = c[1].get("params")
+            if isinstance(params_arg, list):
+                for row in params_arg:
+                    assert "graphUri" not in row
+
+
+# ---------------------------------------------------------------------------
+# Neo4jStore.triples() — context-based graph_uri filtering
+# ---------------------------------------------------------------------------
+
+class TestNeo4jStoreTriplesNamedGraphs:
+    def _node_row(self, uri, props=None, labels=None, graph_uri=None):
+        p = {"uri": uri}
+        if graph_uri is not None:
+            p["graphUri"] = graph_uri
+        if props:
+            p.update(props)
+        return {"uri": uri, "props": p, "extra_labels": labels or []}
+
+    def test_triples_no_context_no_graph_uri_filter(self):
+        """No context → all_nodes_query without graphUri parameter."""
+        store = make_store(named_graphs=True)
+        row = self._node_row(f"{EX}s", {"name": "Alice"})
+        _mock_run(store, [row], [])  # nodes, then rels
+
+        list(store.triples((None, None, None)))
+        # Verify session.run was called without graphUri kwarg for first call
+        first_call = store.session.run.call_args_list[0]
+        assert "graphUri" not in first_call[1]
+
+    def test_triples_with_context_passes_graphUri(self):
+        """context supplied → query includes graphUri kwarg."""
+        store = make_store(named_graphs=True)
+        row = self._node_row(f"{EX}s", {"name": "Alice"}, graph_uri=G1)
+        _mock_run(store, [row], [])
+
+        ctx = make_graph(G1)
+        list(store.triples((None, None, None), context=ctx))
+
+        first_call = store.session.run.call_args_list[0]
+        assert first_call[1].get("graphUri") == G1
+
+    def test_triples_graphUri_prop_skipped_in_output(self):
+        """graphUri node property must NOT appear as a predicate in yielded triples."""
+        store = make_store(named_graphs=True)
+        row = self._node_row(f"{EX}s", {"name": "Alice", "graphUri": G1})
+        _mock_run(store, [row], [])
+
+        ctx = make_graph(G1)
+        results = list(store.triples((None, None, None), context=ctx))
+
+        predicates = [str(t[0][1]) for t in results]
+        assert f"{EX}graphUri" not in predicates
+        assert "graphUri" not in predicates
+
+    def test_triples_with_subject_and_context(self):
+        """Subject + context → node_by_uri_query with both uri and graphUri."""
+        store = make_store(named_graphs=True)
+        row = self._node_row(f"{EX}s", {"name": "Bob"}, graph_uri=G2)
+        _mock_run(store, [row], [])
+
+        ctx = make_graph(G2)
+        list(store.triples((URIRef(f"{EX}s"), None, None), context=ctx))
+
+        first_call = store.session.run.call_args_list[0]
+        assert first_call[1].get("graphUri") == G2
+        assert first_call[1].get("uri") == f"{EX}s"
+
+    def test_named_graphs_false_context_ignored_in_triples(self):
+        """named_graphs=False → context passed to triples() is silently ignored."""
+        store = make_store(named_graphs=False)
+        row = self._node_row(f"{EX}s", {"name": "Carol"})
+        _mock_run(store, [row], [])
+
+        ctx = make_graph(G1)
+        list(store.triples((None, None, None), context=ctx))
+
+        first_call = store.session.run.call_args_list[0]
+        assert "graphUri" not in first_call[1]


### PR DESCRIPTION
## Summary

- Adds `named_graphs: bool = False` to `Neo4jStoreConfig`
- When `True`: `context.identifier` stored as `graphUri` property on every node and relationship
- Same URI in different named graphs = separate Neo4j nodes (n10s `ContextResource` quad semantics)
- `NodeQueryComposer` and `RelationshipQueryComposer` MERGE on `uri + graphUri` in named-graph mode
- `open()` creates a RANGE index instead of uniqueness constraint (duplicate URIs across graphs are valid)
- `triples()` accepts `context` parameter and passes `graphUri` filter to all `ExportQueryComposer` queries
- Default `named_graphs=False` — zero behaviour change for existing users

**Depends on:** #76 (feat/55-triples-export)

## Test plan

- [ ] 29 unit tests: config flag, Neo4jTriple graph_uri param, NodeQueryComposer MERGE key, RelationshipQueryComposer graphUri on rel, ExportQueryComposer context filter, Neo4jStore.add() propagation, triples() context filtering
- [ ] Integration: import same URI in two named graphs → verify two separate nodes in Neo4j

Closes #63