### PR TITLE
docs: general rdflib-neo4j feature tour notebook

### DIFF
--- a/examples/rdflib_neo4j_demo.ipynb
+++ b/examples/rdflib_neo4j_demo.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# rdflib-neo4j — Feature Tour\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/neo4j-labs/rdflib-neo4j/blob/main/notebooks/rdflib_neo4j_demo.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/neo4j-labs/rdflib-neo4j/blob/main/examples/rdflib_neo4j_demo.ipynb)\n",
     "\n",
     "This notebook gives a hands-on tour of `rdflib-neo4j` — the RDFLib store backend\n",
     "for Neo4j. It covers:\n",

--- a/notebooks/rdflib_neo4j_demo.ipynb
+++ b/notebooks/rdflib_neo4j_demo.ipynb
@@ -1,0 +1,608 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# rdflib-neo4j — Feature Tour\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/neo4j-labs/rdflib-neo4j/blob/main/notebooks/rdflib_neo4j_demo.ipynb)\n",
+    "\n",
+    "This notebook gives a hands-on tour of `rdflib-neo4j` — the RDFLib store backend\n",
+    "for Neo4j. It covers:\n",
+    "\n",
+    "| # | Feature | Config option |\n",
+    "|---|---------|---------------|\n",
+    "| 1 | Basic import via `Graph.parse()` | — |\n",
+    "| 2 | URI naming strategies | `handle_vocab_uri_strategy` |\n",
+    "| 3 | XSD datatype coercion | automatic |\n",
+    "| 4 | `handleRDFTypes` — how `rdf:type` is stored | `handle_rdf_types_strategy` |\n",
+    "| 5 | Blank node → `bnode://` URI mapping | automatic |\n",
+    "| 6 | Preview / dry-run mode | `preview=True` |\n",
+    "| 7 | `graph.remove()` — triple deletion | — |\n",
+    "| 8 | `graph.triples()` / iteration / serialization | — |\n",
+    "| 9 | Multi-value properties | `handle_multival_strategy` |\n",
+    "|10 | Node cache — performance tuning | `cache_size` |\n",
+    "\n",
+    "### The story\n",
+    "\n",
+    "We manage an RDF knowledge graph for a small research lab: people, publications,\n",
+    "and affiliations. We'll import, inspect, modify and query it step by step."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 0. Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q rdflib-neo4j neo4j python-dotenv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "from neo4j import GraphDatabase\n",
+    "\n",
+    "load_dotenv()  # reads NEO4J_URI, NEO4J_USERNAME, NEO4J_PASSWORD, NEO4J_DATABASE from .env\n",
+    "\n",
+    "URI      = os.environ[\"NEO4J_URI\"]\n",
+    "USER     = os.environ[\"NEO4J_USERNAME\"]\n",
+    "PASSWORD = os.environ[\"NEO4J_PASSWORD\"]\n",
+    "DATABASE = os.environ.get(\"NEO4J_DATABASE\", \"neo4j\")\n",
+    "\n",
+    "driver = GraphDatabase.driver(URI, auth=(USER, PASSWORD))\n",
+    "driver.verify_connectivity()\n",
+    "print(f\"Connected to {URI} / {DATABASE}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def cypher(q, **params):\n",
+    "    records, _, _ = driver.execute_query(q, params, database_=DATABASE)\n",
+    "    return records\n",
+    "\n",
+    "def reset_db():\n",
+    "    cypher(\"MATCH (n) DETACH DELETE n\")\n",
+    "\n",
+    "def ensure_constraint():\n",
+    "    cypher(\n",
+    "        \"CREATE CONSTRAINT n10s_unique_uri IF NOT EXISTS \"\n",
+    "        \"FOR (r:Resource) REQUIRE r.uri IS UNIQUE\"\n",
+    "    )\n",
+    "\n",
+    "ensure_constraint()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Basic Import\n",
+    "\n",
+    "`Graph(store=Neo4jStore(config))` gives you a standard rdflib graph that\n",
+    "transparently persists every triple to Neo4j. `rdf:type` becomes a label;\n",
+    "literal predicates become properties; URI predicates become relationships."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rdflib import Graph\n",
+    "from rdflib_neo4j import Neo4jStoreConfig, Neo4jStore, HANDLE_VOCAB_URI_STRATEGY\n",
+    "\n",
+    "TURTLE = \"\"\"\n",
+    "@prefix schema: <https://schema.org/> .\n",
+    "@prefix ex:     <http://lab.example.org/> .\n",
+    "@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .\n",
+    "\n",
+    "ex:alice a schema:Person ;\n",
+    "    schema:name        \"Alice Chen\" ;\n",
+    "    schema:email       \"alice@lab.example.org\" ;\n",
+    "    schema:birthDate   \"1990-03-15\"^^xsd:date ;\n",
+    "    schema:alumniOf    ex:mit ;\n",
+    "    schema:memberOf    ex:lab .\n",
+    "\n",
+    "ex:bob a schema:Person ;\n",
+    "    schema:name        \"Bob Smith\" ;\n",
+    "    schema:email       \"bob@lab.example.org\" ;\n",
+    "    schema:birthDate   \"1985-07-22\"^^xsd:date ;\n",
+    "    schema:memberOf    ex:lab .\n",
+    "\n",
+    "ex:lab a schema:Organization ;\n",
+    "    schema:name        \"Graph Research Lab\" ;\n",
+    "    schema:foundingYear 2018 .\n",
+    "\n",
+    "ex:mit a schema:Organization ;\n",
+    "    schema:name \"MIT\" .\n",
+    "\n",
+    "ex:paper1 a schema:ScholarlyArticle ;\n",
+    "    schema:name   \"Graph Neural Networks for RDF\" ;\n",
+    "    schema:author ex:alice ;\n",
+    "    schema:author ex:bob ;\n",
+    "    schema:datePublished \"2023-01-10\"^^xsd:date ;\n",
+    "    schema:citation 42 .\n",
+    "\"\"\"\n",
+    "\n",
+    "reset_db()\n",
+    "\n",
+    "auth_data = {\"uri\": URI, \"database\": DATABASE, \"user\": USER, \"pwd\": PASSWORD}\n",
+    "config = Neo4jStoreConfig(\n",
+    "    auth_data=auth_data,\n",
+    "    custom_prefixes={\"schema\": \"https://schema.org/\"},\n",
+    "    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,\n",
+    "    batching=False,\n",
+    ")\n",
+    "g = Graph(store=Neo4jStore(config=config))\n",
+    "g.open(config, create=True)\n",
+    "g.parse(data=TURTLE, format=\"ttl\")\n",
+    "g.close(True)\n",
+    "\n",
+    "for r in cypher(\"MATCH (n:Resource) RETURN labels(n) AS lbl, n.uri AS uri ORDER BY uri\"):\n",
+    "    print(f\"{str(r['lbl']):30}  {r['uri']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. URI Naming Strategies\n",
+    "\n",
+    "`handle_vocab_uri_strategy` controls how RDF predicate and type URIs map to\n",
+    "Neo4j property and label names.\n",
+    "\n",
+    "| Strategy | `schema:name` becomes | `schema:Person` becomes |\n",
+    "|---|---|---|\n",
+    "| `IGNORE` | `name` | `Person` |\n",
+    "| `SHORTEN` | `schema__name` | `schema__Person` |\n",
+    "| `SHORTEN_STRICT` | `schema__name` (or error if prefix unknown) | `schema__Person` |\n",
+    "| `KEEP` | `https://schema.org/name` | `https://schema.org/Person` |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# See what names are stored with IGNORE (current import)\n",
+    "for r in cypher(\"MATCH (p:Person) RETURN keys(p) AS props LIMIT 1\"):\n",
+    "    print(\"Properties with IGNORE strategy:\", r[\"props\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Preview what SHORTEN would produce (no DB write)\n",
+    "config_shorten = Neo4jStoreConfig(\n",
+    "    custom_prefixes={\"schema\": \"https://schema.org/\"},\n",
+    "    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.SHORTEN,\n",
+    "    preview=True,\n",
+    ")\n",
+    "g_preview = Graph(store=Neo4jStore(config=config_shorten))\n",
+    "g_preview.parse(data=\"\"\"\n",
+    "    @prefix schema: <https://schema.org/> .\n",
+    "    @prefix ex: <http://lab.example.org/> .\n",
+    "    ex:test a schema:Person ; schema:name \\\"Test\\\" .\n",
+    "\"\"\", format=\"ttl\")\n",
+    "\n",
+    "for q, p in config_shorten.get_preview_results()[:2]:\n",
+    "    print(q[:100])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. XSD Datatype Coercion\n",
+    "\n",
+    "Typed RDF literals are automatically coerced to native Neo4j types:\n",
+    "\n",
+    "| XSD type | Neo4j type |\n",
+    "|---|---|\n",
+    "| `xsd:integer`, `xsd:long` | Integer |\n",
+    "| `xsd:decimal`, `xsd:float`, `xsd:double` | Float |\n",
+    "| `xsd:boolean` | Boolean |\n",
+    "| `xsd:date` | Date |\n",
+    "| `xsd:dateTime` | DateTime |\n",
+    "| `xsd:string`, `xsd:anyURI` | String |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for r in cypher(\n",
+    "    \"MATCH (p:Person) RETURN p.name AS name, p.birthDate AS bd, \"\n",
+    "    \"apoc.meta.type(p.birthDate) AS bd_type ORDER BY name\"\n",
+    "):\n",
+    "    print(f\"{r['name']:15}  birthDate={r['bd']}  neo4j_type={r['bd_type']}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# citation count is stored as an integer — use it in arithmetic\n",
+    "for r in cypher(\n",
+    "    \"MATCH (a:ScholarlyArticle) RETURN a.name AS title, a.citation AS cites, \"\n",
+    "    \"a.citation * 10 AS impact_score\"\n",
+    "):\n",
+    "    print(r[\"title\"], \"— citations:\", r[\"cites\"], \"→ impact:\", r[\"impact_score\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. handleRDFTypes — How `rdf:type` Is Stored\n",
+    "\n",
+    "By default, `rdf:type` becomes a Neo4j **label** only. You can also store it\n",
+    "as a **relationship** (for queries that need to traverse the type hierarchy)\n",
+    "or as **both**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rdflib_neo4j.config.const import HandleRDFTypesStrategy\n",
+    "\n",
+    "SAMPLE = \"\"\"\n",
+    "@prefix schema: <https://schema.org/> .\n",
+    "@prefix ex:     <http://lab.example.org/> .\n",
+    "ex:demo a schema:Person ; schema:name \"Demo\" .\n",
+    "\"\"\"\n",
+    "\n",
+    "for strategy in [HandleRDFTypesStrategy.LABELS,\n",
+    "                 HandleRDFTypesStrategy.NODES,\n",
+    "                 HandleRDFTypesStrategy.LABELS_AND_NODES]:\n",
+    "    cfg = Neo4jStoreConfig(\n",
+    "        custom_prefixes={\"schema\": \"https://schema.org/\"},\n",
+    "        handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,\n",
+    "        handle_rdf_types_strategy=strategy,\n",
+    "        preview=True,\n",
+    "    )\n",
+    "    g_tmp = Graph(store=Neo4jStore(config=cfg))\n",
+    "    g_tmp.parse(data=SAMPLE, format=\"ttl\")\n",
+    "    print(f\"\\n── Strategy: {strategy.name} ──\")\n",
+    "    for q, _ in cfg.get_preview_results():\n",
+    "        if \"Person\" in q or \"rdf__type\" in q or \"type\" in q.lower():\n",
+    "            print(\" \", q[:120])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Blank Nodes → `bnode://` URIs\n",
+    "\n",
+    "RDF blank nodes (anonymous resources) have no URI. rdflib-neo4j maps them to\n",
+    "synthetic `bnode://<id>` URIs so they can be stored as regular `Resource` nodes\n",
+    "and queried back."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rdflib import Graph, BNode, URIRef, Literal, RDF\n",
+    "from rdflib import Namespace\n",
+    "\n",
+    "SCHEMA = Namespace(\"https://schema.org/\")\n",
+    "EX     = Namespace(\"http://lab.example.org/\")\n",
+    "\n",
+    "g_bn = Graph(store=Neo4jStore(config=config))\n",
+    "g_bn.open(config, create=False)\n",
+    "\n",
+    "# Add an address as a blank node\n",
+    "addr = BNode()\n",
+    "g_bn.add((EX.alice, SCHEMA.address, addr))\n",
+    "g_bn.add((addr, SCHEMA.streetAddress, Literal(\"1 Infinite Loop\")))\n",
+    "g_bn.add((addr, SCHEMA.addressLocality, Literal(\"Cambridge\")))\n",
+    "g_bn.close(True)\n",
+    "\n",
+    "# The blank node is stored with a bnode:// URI\n",
+    "for r in cypher(\n",
+    "    \"MATCH (p:Person {name: 'Alice Chen'})-[:address]->(addr) \"\n",
+    "    \"RETURN addr.uri AS bnode_uri, addr.streetAddress AS street, addr.addressLocality AS city\"\n",
+    "):\n",
+    "    print(\"BNode URI:\", r[\"bnode_uri\"])\n",
+    "    print(\"Street:   \", r[\"street\"])\n",
+    "    print(\"City:     \", r[\"city\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Preview / Dry-Run Mode\n",
+    "\n",
+    "`preview=True` captures all Cypher queries that *would* be sent to Neo4j —\n",
+    "without executing them. Ideal for testing pipelines or auditing without a DB."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preview_config = Neo4jStoreConfig(\n",
+    "    custom_prefixes={\"schema\": \"https://schema.org/\"},\n",
+    "    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,\n",
+    "    preview=True,\n",
+    ")\n",
+    "\n",
+    "g_dry = Graph(store=Neo4jStore(config=preview_config))\n",
+    "g_dry.parse(data=\"\"\"\n",
+    "    @prefix schema: <https://schema.org/> .\n",
+    "    @prefix ex: <http://lab.example.org/> .\n",
+    "    ex:carol a schema:Person ; schema:name \\\"Carol\\\" ; schema:email \\\"carol@lab.org\\\" .\n",
+    "\"\"\", format=\"ttl\")\n",
+    "\n",
+    "results = preview_config.get_preview_results()\n",
+    "print(f\"Captured {len(results)} queries (no data written):\\n\")\n",
+    "for i, (q, p) in enumerate(results, 1):\n",
+    "    print(f\"[{i}] {q}\")\n",
+    "    if p:\n",
+    "        print(f\"    params: {p}\")\n",
+    "    print()\n",
+    "\n",
+    "preview_config.clear_preview_results()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Removing Triples\n",
+    "\n",
+    "`graph.remove((s, p, o))` maps to the appropriate Cypher operation:\n",
+    "- Literal object → `REMOVE n.property` \n",
+    "- `rdf:type` predicate → `REMOVE n:Label`\n",
+    "- URI/BNode object → `DELETE relationship`\n",
+    "- Wildcards (`None`) → remove all matching triples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g_edit = Graph(store=Neo4jStore(config=config))\n",
+    "g_edit.open(config, create=False)\n",
+    "\n",
+    "print(\"Before removal:\")\n",
+    "for r in cypher(\"MATCH (p:Person {name: 'Alice Chen'}) RETURN labels(p) AS l, keys(p) AS k\"):\n",
+    "    print(\"  labels:\", r[\"l\"])\n",
+    "    print(\"  props: \", r[\"k\"])\n",
+    "\n",
+    "# Remove the email property\n",
+    "g_edit.remove((EX.alice, SCHEMA.email, None))\n",
+    "\n",
+    "# Remove the alumniOf relationship\n",
+    "g_edit.remove((EX.alice, SCHEMA.alumniOf, EX.mit))\n",
+    "\n",
+    "g_edit.close(True)\n",
+    "\n",
+    "print(\"\\nAfter removal:\")\n",
+    "for r in cypher(\"MATCH (p:Person {name: 'Alice Chen'}) RETURN keys(p) AS k\"):\n",
+    "    print(\"  props: \", r[\"k\"])  # email gone\n",
+    "\n",
+    "# alumniOf relationship gone\n",
+    "rels = cypher(\"MATCH (p:Person {name: 'Alice Chen'})-[r:alumniOf]->() RETURN count(r) AS c\")\n",
+    "print(\"  alumniOf rels:\", rels[0][\"c\"])  # should be 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Graph Iteration — `triples()`, `__len__()`, `__iter__()`\n",
+    "\n",
+    "rdflib-neo4j implements the full rdflib Store interface:\n",
+    "- `len(g)` — count of triples\n",
+    "- `for s, p, o in g` — iterate all triples\n",
+    "- `g.triples((s, p, o))` — pattern-matched iteration\n",
+    "- `g.serialize(format=\"turtle\")` — round-trip to RDF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g_read = Graph(store=Neo4jStore(config=config))\n",
+    "g_read.open(config, create=False)\n",
+    "\n",
+    "print(f\"Total triples: {len(g_read)}\")\n",
+    "\n",
+    "# Pattern match: all rdf:type triples\n",
+    "print(\"\\nTypes in the graph:\")\n",
+    "from rdflib import RDF\n",
+    "for s, p, o in g_read.triples((None, RDF.type, None)):\n",
+    "    print(f\"  {s.split('/')[-1]:15} a  {o.split('/')[-1]}\")\n",
+    "\n",
+    "g_read.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Serialize back to Turtle — full round-trip\n",
+    "g_ser = Graph(store=Neo4jStore(config=config))\n",
+    "g_ser.open(config, create=False)\n",
+    "ttl = g_ser.serialize(format=\"turtle\")\n",
+    "g_ser.close()\n",
+    "\n",
+    "# Show first 30 lines\n",
+    "for line in ttl.splitlines()[:30]:\n",
+    "    print(line)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. Multi-Value Properties\n",
+    "\n",
+    "By default, writing the same predicate twice overwrites the previous value (`OVERWRITE`).\n",
+    "Use `ARRAY` strategy + `multival_props_names` to accumulate values as a Neo4j list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rdflib_neo4j.config.const import HANDLE_MULTIVAL_STRATEGY\n",
+    "\n",
+    "# Re-import paper with both authors stored as an array\n",
+    "multi_config = Neo4jStoreConfig(\n",
+    "    auth_data=auth_data,\n",
+    "    custom_prefixes={\"schema\": \"https://schema.org/\"},\n",
+    "    handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,\n",
+    "    handle_multival_strategy=HANDLE_MULTIVAL_STRATEGY.ARRAY,\n",
+    "    batching=False,\n",
+    ")\n",
+    "\n",
+    "PAPER_TURTLE = \"\"\"\n",
+    "@prefix schema: <https://schema.org/> .\n",
+    "@prefix ex:     <http://lab.example.org/> .\n",
+    "ex:paper2 a schema:ScholarlyArticle ;\n",
+    "    schema:name   \"Multi-Author Paper\" ;\n",
+    "    schema:keyword \"graphs\" ;\n",
+    "    schema:keyword \"RDF\" ;\n",
+    "    schema:keyword \"Neo4j\" .\n",
+    "\"\"\"\n",
+    "\n",
+    "g_multi = Graph(store=Neo4jStore(config=multi_config))\n",
+    "g_multi.open(multi_config, create=False)\n",
+    "g_multi.parse(data=PAPER_TURTLE, format=\"ttl\")\n",
+    "g_multi.close(True)\n",
+    "\n",
+    "for r in cypher(\"MATCH (a:ScholarlyArticle {name: 'Multi-Author Paper'}) RETURN a.keyword AS kw\"):\n",
+    "    print(\"keywords (array):\", r[\"kw\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 10. Node Cache — Performance Tuning\n",
+    "\n",
+    "By default, every triple write issues a `MERGE` query to Neo4j — even if the\n",
+    "subject node was just created. The in-process node cache skips redundant MERGEs\n",
+    "for nodes already seen in the current session.\n",
+    "\n",
+    "Use `cache_size` in `Neo4jStoreConfig` to control memory usage (0 = disabled)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "LARGE_TURTLE = \"\\n\".join([\n",
+    "    f\"\"\"<http://lab.example.org/person{i}> a <https://schema.org/Person> ;\n",
+    "    <https://schema.org/name> \\\"Person {i}\\\" ;\n",
+    "    <https://schema.org/age>  {20 + i % 50} .\"\"\"\n",
+    "    for i in range(200)\n",
+    "])\n",
+    "\n",
+    "for cache_size in [0, 500]:\n",
+    "    reset_db(); ensure_constraint()\n",
+    "    cfg = Neo4jStoreConfig(\n",
+    "        auth_data=auth_data,\n",
+    "        custom_prefixes={\"schema\": \"https://schema.org/\"},\n",
+    "        handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,\n",
+    "        cache_size=cache_size,\n",
+    "        batching=False,\n",
+    "    )\n",
+    "    g_perf = Graph(store=Neo4jStore(config=cfg))\n",
+    "    g_perf.open(cfg, create=True)\n",
+    "    t0 = time.perf_counter()\n",
+    "    g_perf.parse(data=LARGE_TURTLE, format=\"ttl\")\n",
+    "    g_perf.close(True)\n",
+    "    elapsed = time.perf_counter() - t0\n",
+    "    label = \"no cache\" if cache_size == 0 else f\"cache_size={cache_size}\"\n",
+    "    print(f\"{label:20}  {elapsed:.2f}s\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Appendix — What's in the Other Notebooks\n",
+    "\n",
+    "| Notebook | PR | Topic |\n",
+    "|---|---|---|\n",
+    "| [`cypher_dsl_demo.ipynb`](cypher_dsl_demo.ipynb) | #81 | Typed Cypher 25 DSL — `CypherQuery` builder |\n",
+    "| [`sparql_transpiler_demo.ipynb`](sparql_transpiler_demo.ipynb) | #83 | SPARQL → Cypher transpiler |\n",
+    "| [`named_graphs_demo.ipynb`](named_graphs_demo.ipynb) | #79 | Named graph / quad support |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "driver.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/rdflib_neo4j_demo.ipynb
+++ b/notebooks/rdflib_neo4j_demo.ipynb
@@ -73,22 +73,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "def cypher(q, **params):\n",
-    "    records, _, _ = driver.execute_query(q, params, database_=DATABASE)\n",
-    "    return records\n",
-    "\n",
-    "def reset_db():\n",
-    "    cypher(\"MATCH (n) DETACH DELETE n\")\n",
-    "\n",
-    "def ensure_constraint():\n",
-    "    cypher(\n",
-    "        \"CREATE CONSTRAINT n10s_unique_uri IF NOT EXISTS \"\n",
-    "        \"FOR (r:Resource) REQUIRE r.uri IS UNIQUE\"\n",
-    "    )\n",
-    "\n",
-    "ensure_constraint()"
-   ]
+   "source": "def cypher(q, **params):\n    records, _, _ = driver.execute_query(q, params, database_=DATABASE)\n    return records\n\ndef reset_db():\n    cypher(\"MATCH (n) DETACH DELETE n\")\n    # Note: Neo4jStore.open(config, create=True) recreates the constraint/index automatically."
   },
   {
    "cell_type": "markdown",
@@ -540,34 +525,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import time\n",
-    "\n",
-    "LARGE_TURTLE = \"\\n\".join([\n",
-    "    f\"\"\"<http://lab.example.org/person{i}> a <https://schema.org/Person> ;\n",
-    "    <https://schema.org/name> \\\"Person {i}\\\" ;\n",
-    "    <https://schema.org/age>  {20 + i % 50} .\"\"\"\n",
-    "    for i in range(200)\n",
-    "])\n",
-    "\n",
-    "for cache_size in [0, 500]:\n",
-    "    reset_db(); ensure_constraint()\n",
-    "    cfg = Neo4jStoreConfig(\n",
-    "        auth_data=auth_data,\n",
-    "        custom_prefixes={\"schema\": \"https://schema.org/\"},\n",
-    "        handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,\n",
-    "        cache_size=cache_size,\n",
-    "        batching=False,\n",
-    "    )\n",
-    "    g_perf = Graph(store=Neo4jStore(config=cfg))\n",
-    "    g_perf.open(cfg, create=True)\n",
-    "    t0 = time.perf_counter()\n",
-    "    g_perf.parse(data=LARGE_TURTLE, format=\"ttl\")\n",
-    "    g_perf.close(True)\n",
-    "    elapsed = time.perf_counter() - t0\n",
-    "    label = \"no cache\" if cache_size == 0 else f\"cache_size={cache_size}\"\n",
-    "    print(f\"{label:20}  {elapsed:.2f}s\")"
-   ]
+   "source": "import time\n\nLARGE_TURTLE = \"\\n\".join([\n    f\"\"\"<http://lab.example.org/person{i}> a <https://schema.org/Person> ;\n    <https://schema.org/name> \\\"Person {i}\\\" ;\n    <https://schema.org/age>  {20 + i % 50} .\"\"\"\n    for i in range(200)\n])\n\nfor cache_size in [0, 500]:\n    reset_db()\n    cfg = Neo4jStoreConfig(\n        auth_data=auth_data,\n        custom_prefixes={\"schema\": \"https://schema.org/\"},\n        handle_vocab_uri_strategy=HANDLE_VOCAB_URI_STRATEGY.IGNORE,\n        cache_size=cache_size,\n        batching=False,\n    )\n    g_perf = Graph(store=Neo4jStore(config=cfg))\n    g_perf.open(cfg, create=True)  # create=True recreates the constraint\n    t0 = time.perf_counter()\n    g_perf.parse(data=LARGE_TURTLE, format=\"ttl\")\n    g_perf.close(True)\n    elapsed = time.perf_counter() - t0\n    label = \"no cache\" if cache_size == 0 else f\"cache_size={cache_size}\"\n    print(f\"{label:20}  {elapsed:.2f}s\")"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Adds a comprehensive Jupyter notebook (`notebooks/rdflib_neo4j_demo.ipynb`) demonstrating the full rdflib-neo4j feature set end-to-end, using a research lab knowledge graph as the running story.

## Features covered

| # | Feature | Config option |
|---|---------|---------------|
| 1 | Basic `Graph.parse()` import | — |
| 2 | URI naming strategies (IGNORE / SHORTEN / SHORTEN_STRICT / KEEP) | `handle_vocab_uri_strategy` |
| 3 | XSD datatype coercion → native Neo4j types | automatic |
| 4 | `handleRDFTypes` — LABELS / NODES / LABELS_AND_NODES | `handle_rdf_types_strategy` |
| 5 | Blank node → `bnode://` URI mapping | automatic |
| 6 | Preview / dry-run mode | `preview=True` |
| 7 | `graph.remove()` triple deletion | — |
| 8 | `graph.triples()` / `__iter__()` / `serialize()` | — |
| 9 | Multi-value properties as arrays | `handle_multival_strategy=ARRAY` |
| 10 | Node cache performance tuning | `cache_size` |

## Dataset

Research lab with persons, publications, organizations — small enough to follow but varied enough to showcase all features.

## Credentials

Loaded from `.env` via `python-dotenv`:
```
NEO4J_URI=bolt://localhost:7687
NEO4J_USERNAME=neo4j
NEO4J_PASSWORD=password
NEO4J_DATABASE=neo4j
```

[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/neo4j-labs/rdflib-neo4j/blob/main/notebooks/rdflib_neo4j_demo.ipynb)

## Related

- PR #81 — Cypher DSL notebook
- PR #83 — SPARQL transpiler notebook  
- PR #79 — Named graph notebook