### PR TITLE
style: fix pre-existing ruff lint errors

### DIFF
--- a/rdflib_neo4j/Neo4jStore.py
+++ b/rdflib_neo4j/Neo4jStore.py
@@ -132,7 +132,7 @@ class Neo4jStore(Store):
         self.__flushBuffer(commit_nodes, commit_rels)
 
     def remove(self, triple, context=None, txn=None):
-        raise NotImplemented("This is a streamer so it doesn't preserve the state, there is no removal feature.")
+        raise NotImplementedError("This is a streamer so it doesn't preserve the state, there is no removal feature.")
 
     def __close_on_error(self):
         """
@@ -173,7 +173,6 @@ class Neo4jStore(Store):
         This function initializes the driver and session based on the provided configuration.
 
         """
-        auth_data = self.config.auth_data
         self.session = self.__get_driver().session(
             default_access_mode=WRITE_ACCESS
         )

--- a/rdflib_neo4j/Neo4jTriple.py
+++ b/rdflib_neo4j/Neo4jTriple.py
@@ -156,7 +156,7 @@ class Neo4jTriple:
         # Getting a property
         if isinstance(object, Literal):
             # Neo4j Python driver does not support decimal params
-            value = float(object.toPython()) if type(object.toPython()) == Decimal else object.toPython()
+            value = float(object.toPython()) if isinstance(object.toPython(), Decimal) else object.toPython()
             prop_name = self.handle_vocab_uri(mappings, predicate)
 
             # If at least a name is defined and the predicate is one of the properties defined by the user

--- a/rdflib_neo4j/config/const.py
+++ b/rdflib_neo4j/config/const.py
@@ -57,7 +57,7 @@ class CypherMultipleTypesMultiValueException(Exception):
         super().__init__()
 
     def __str__(self):
-        return f"""Values of a multivalued property must have the same datatype."""
+        return """Values of a multivalued property must have the same datatype."""
 
 NEO4J_DRIVER_MULTIPLE_TYPE_ERROR_MESSAGE = """{code: Neo.ClientError.Statement.TypeError} {message: Neo4j only supports a subset of Cypher types for storage as singleton or array properties. Please refer to section cypher/syntax/values of the manual for more details.}"""
 NEO4J_DRIVER_DICT_MESSAGE = {NEO4J_DRIVER_MULTIPLE_TYPE_ERROR_MESSAGE: CypherMultipleTypesMultiValueException}

--- a/rdflib_neo4j/query_composers/NodeQueryComposer.py
+++ b/rdflib_neo4j/query_composers/NodeQueryComposer.py
@@ -61,7 +61,7 @@ class NodeQueryComposer:
             str: The Neo4j query.
         """
 
-        q = f''' UNWIND $params as param MERGE (n:Resource{{ uri : param["uri"] }}) '''
+        q = ''' UNWIND $params as param MERGE (n:Resource{ uri : param["uri"] }) '''
         if self.labels:
             q += f'''SET {', '.join([f"""n:`{label}`""" for label in self.labels])} '''
         if self.props or self.multi_props:

--- a/rdflib_neo4j/query_composers/RelationshipQueryComposer.py
+++ b/rdflib_neo4j/query_composers/RelationshipQueryComposer.py
@@ -25,7 +25,7 @@ class RelationshipQueryComposer:
             props: The properties to add.
         """
         self.props.update(props)
-        raise NotImplemented("TO WORK ON THIS, WE NEED TEST DATA")
+        raise NotImplementedError("TO WORK ON THIS, WE NEED TEST DATA")
 
     def add_query_param(self, from_node, to_node):
         """
@@ -45,13 +45,13 @@ class RelationshipQueryComposer:
         Returns:
             str: The Neo4j query.
         """
-        q = f''' UNWIND $params as param 
-                 MERGE (from:Resource{{ uri : param["from"] }}) 
-                 MERGE (to:Resource{{ uri : param["to"] }})
+        q = ''' UNWIND $params as param 
+                 MERGE (from:Resource{ uri : param["from"] }) 
+                 MERGE (to:Resource{ uri : param["to"] })
              '''
         q += f''' MERGE (from)-[r:`{self.rel_type}`]->(to)'''
         if self.props:
-            raise NotImplemented
+            raise NotImplementedError
             # q += f'''SET {', '.join([f"""r.`{prop}` = coalesce(param["{prop}"],null)""" for prop in self.props])}'''
         return q
 


### PR DESCRIPTION
## Summary
Clears the 8 pre-existing `ruff` errors so the CI **Lint** step (`ruff check rdflib_neo4j/ test/unit/`) passes. No behavior change.

Split out from #87 (rdflib security/VEX) to keep that PR scoped to the dependency change.

## Changes
- `raise NotImplemented` → `raise NotImplementedError` (F901) ×3 — `NotImplemented` is not an exception and would itself raise `TypeError`.
- Drop `f` prefix on f-strings with no placeholders (F541) ×3 — escaped `{{ }}` become literal `{ }`, so the rendered Cypher is identical.
- Remove unused local `auth_data` in `__create_session` (F841).
- `type(x) == Decimal` → `isinstance(x, Decimal)` (E721).

## Testing
- `ruff check rdflib_neo4j/ test/unit/` ✅ All checks passed
- `compileall` ✅ · unit tests ✅ (12 passed)