### PR TITLE
style: fix ruff lint errors (greens the Lint job on #86)

### DIFF
--- a/rdflib_neo4j/Neo4jStore.py
+++ b/rdflib_neo4j/Neo4jStore.py
@@ -131,7 +131,7 @@ class Neo4jStore(Store):
         self.__flushBuffer(commit_nodes, commit_rels)
 
     def remove(self, triple, context=None, txn=None):
-        raise NotImplemented("This is a streamer so it doesn't preserve the state, there is no removal feature.")
+        raise NotImplementedError("This is a streamer so it doesn't preserve the state, there is no removal feature.")
 
     def __close_on_error(self):
         """
@@ -172,7 +172,6 @@ class Neo4jStore(Store):
         This function initializes the driver and session based on the provided configuration.
 
         """
-        auth_data = self.config.auth_data
         self.session = self.__get_driver().session(
             default_access_mode=WRITE_ACCESS
         )

--- a/rdflib_neo4j/Neo4jTriple.py
+++ b/rdflib_neo4j/Neo4jTriple.py
@@ -156,7 +156,7 @@ class Neo4jTriple:
         # Getting a property
         if isinstance(object, Literal):
             # Neo4j Python driver does not support decimal params
-            value = float(object.toPython()) if type(object.toPython()) == Decimal else object.toPython()
+            value = float(object.toPython()) if isinstance(object.toPython(), Decimal) else object.toPython()
             prop_name = self.handle_vocab_uri(mappings, predicate)
 
             # If at least a name is defined and the predicate is one of the properties defined by the user

--- a/rdflib_neo4j/config/const.py
+++ b/rdflib_neo4j/config/const.py
@@ -57,7 +57,7 @@ class CypherMultipleTypesMultiValueException(Exception):
         super().__init__()
 
     def __str__(self):
-        return f"""Values of a multivalued property must have the same datatype."""
+        return """Values of a multivalued property must have the same datatype."""
 
 NEO4J_DRIVER_MULTIPLE_TYPE_ERROR_MESSAGE = """{code: Neo.ClientError.Statement.TypeError} {message: Neo4j only supports a subset of Cypher types for storage as singleton or array properties. Please refer to section cypher/syntax/values of the manual for more details.}"""
 NEO4J_DRIVER_DICT_MESSAGE = {NEO4J_DRIVER_MULTIPLE_TYPE_ERROR_MESSAGE: CypherMultipleTypesMultiValueException}

--- a/rdflib_neo4j/query_composers/NodeQueryComposer.py
+++ b/rdflib_neo4j/query_composers/NodeQueryComposer.py
@@ -61,7 +61,7 @@ class NodeQueryComposer:
             str: The Neo4j query.
         """
 
-        q = f''' UNWIND $params as param MERGE (n:Resource{{ uri : param["uri"] }}) '''
+        q = ''' UNWIND $params as param MERGE (n:Resource{ uri : param["uri"] }) '''
         if self.labels:
             q += f'''SET {', '.join([f"""n:`{label}`""" for label in self.labels])} '''
         if self.props or self.multi_props:

--- a/rdflib_neo4j/query_composers/RelationshipQueryComposer.py
+++ b/rdflib_neo4j/query_composers/RelationshipQueryComposer.py
@@ -25,7 +25,7 @@ class RelationshipQueryComposer:
             props: The properties to add.
         """
         self.props.update(props)
-        raise NotImplemented("TO WORK ON THIS, WE NEED TEST DATA")
+        raise NotImplementedError("TO WORK ON THIS, WE NEED TEST DATA")
 
     def add_query_param(self, from_node, to_node):
         """
@@ -45,13 +45,13 @@ class RelationshipQueryComposer:
         Returns:
             str: The Neo4j query.
         """
-        q = f''' UNWIND $params as param 
-                 MERGE (from:Resource{{ uri : param["from"] }}) 
-                 MERGE (to:Resource{{ uri : param["to"] }})
+        q = ''' UNWIND $params as param 
+                 MERGE (from:Resource{ uri : param["from"] }) 
+                 MERGE (to:Resource{ uri : param["to"] })
              '''
         q += f''' MERGE (from)-[r:`{self.rel_type}`]->(to)'''
         if self.props:
-            raise NotImplemented
+            raise NotImplementedError
             # q += f'''SET {', '.join([f"""r.`{prop}` = coalesce(param["{prop}"],null)""" for prop in self.props])}'''
         return q
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,13 @@
+# Ruff configuration for rdflib-neo4j.
+#
+# Integration test modules import pytest fixtures by name
+# (e.g. `from test.integration.fixtures import neo4j_driver, graph_store`)
+# and then receive them as test-function arguments. Ruff cannot model
+# pytest's fixture injection, so it reports these as:
+#   F401 — imported but unused (the import is required for fixture discovery)
+#   F811 — redefinition       (the function parameter shadows the import)
+# Both are false positives for this pattern, so they are ignored for the
+# integration test package only. Source code is linted with the full default
+# rule set.
+[lint.per-file-ignores]
+"test/integration/*" = ["F401", "F811"]


### PR DESCRIPTION
Targets `chore/ci-integration-tests` to green the **Lint** job on #86.

The new CI lints the full `rdflib_neo4j/ test/` tree, which surfaced **123 ruff errors**: 8 real source errors + 115 false positives from the pytest fixture-import pattern in `test/integration/`.

## Source code — 8 real errors, fixed
- `raise NotImplemented` → `raise NotImplementedError` (F901) ×3 — `NotImplemented` is not an exception and would itself raise `TypeError`.
- Drop `f` prefix on f-strings with no placeholders (F541) ×3 — escaped `{{ }}` become literal `{ }`, so the rendered Cypher is identical.
- Remove unused local `auth_data` in `__create_session` (F841).
- `type(x) == Decimal` → `isinstance(x, Decimal)` (E721).

## Tests — 115 false positives, configured (not edited)
`test/integration/*` modules import pytest fixtures by name (`from test.integration.fixtures import neo4j_driver, graph_store, ...`) and receive them as test-function arguments. Ruff can't model pytest fixture injection, so it reports F401 (unused import) and F811 (redefinition). **Removing the imports would break fixture discovery**, so `ruff.toml` ignores `F401`/`F811` for `test/integration/*` only; source keeps the full default rule set.

A cleaner long-term option is moving fixtures into `conftest.py` (auto-discovered, no imports) — deferred to a follow-up since it changes fixture resolution and can't be verified here without a live Neo4j.

## Verification
- `ruff check rdflib_neo4j/ test/` → **All checks passed**
- `compileall` ✅ · 21 integration tests still **collect** cleanly (imports intact)

## Not addressed here (out of scope)
The **Unit tests / Python 3.12** job fails in *Install dependencies*, not lint: `neo4j==5.11.0` can't build on Python 3.12 (`AttributeError: module 'pkgutil' has no attribute 'ImpImporter'` — old build-time setuptools). That's a dependency-compat fix (bump `neo4j`), separate from this PR.